### PR TITLE
SPH-327-EDA-rVvN-SBB

### DIFF
--- a/notebooks/EDA_opschonen_waswordt.ipynb
+++ b/notebooks/EDA_opschonen_waswordt.ipynb
@@ -1276,16 +1276,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
-    "rvvn_with_multiple_vegcodes = number_of_vegcodes_per_rvvn[number_of_vegcodes_per_rvvn > 1].index.to_list()"
+    "rvvn_with_multiple_vegcodes = number_of_vegcodes_per_rvvn[number_of_vegcodes_per_rvvn['SBB'] + number_of_vegcodes_per_rvvn['VvN'] > 1].index.to_list()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -1299,7 +1299,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1311,7 +1311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1320,7 +1320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1329,7 +1329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
@@ -1338,7 +1338,7 @@
        "36"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1349,7 +1349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
@@ -1393,7 +1393,7 @@
        " 'r46Aa01b'}"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Zeer korte analyse wat er potentieel misgaat wanneer we rVvN gaan vertalen naar VvN + SBB. Welke rVvN codes hebben meer dan één vegetatietype (VvN + SBB) en vertalen mogelijk naar verschillende habitattypen.

Deze analyse maakt niet uit voor onze aanpak. Dezelfde aanpak die we hebben doorgesproken met de begeleidingscommissie voor SBB naar VvN gaat hier ook op.