### PR TITLE
SPH-678 FGR/Bodem/FBK typen in opm{i}

### DIFF
--- a/data/mitsjson.json
+++ b/data/mitsjson.json
@@ -7,11 +7,11 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     }
                 ]
             },
@@ -29,11 +29,11 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     }
                 ]
             },
@@ -51,11 +51,11 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     }
                 ]
             },
@@ -70,7 +70,7 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Getijdengebied"
+                "wanted_fgrtype": "Getijdengebied"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -86,11 +86,11 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     }
                 ]
             },
@@ -105,7 +105,7 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Getijdengebied"
+                "wanted_fgrtype": "Getijdengebied"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -118,7 +118,7 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Getijdengebied"
+                "wanted_fgrtype": "Getijdengebied"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -131,7 +131,7 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Getijdengebied"
+                "wanted_fgrtype": "Getijdengebied"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -200,13 +200,13 @@
             },
             {
                 "type": "LBKCriterium",
-                "lbktype": "hoogveenlandschap"
+                "wanted_lbktype": "Hoogveenlandschap"
             }
         ]
     },
     "mits in herstellend hoogveen": {
         "type": "LBKCriterium",
-        "lbktype": "herstellend hoogveen"
+        "wanted_lbktype": "Herstellend hoogveen"
     },
     "mits niet in mozaïek met vegetaties van H3110 en mits geen onderdeel van H7120 en niet in lijnvormige wateren": {
         "type": "NietGeautomatiseerd",
@@ -237,15 +237,15 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Noordzee"
+                "wanted_fgrtype": "Noordzee"
             },
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Getijdengebied"
+                "wanted_fgrtype": "Getijdengebied"
             },
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Duinen"
+                "wanted_fgrtype": "Duinen"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -268,15 +268,15 @@
             "sub_criteria": [
                 {
                     "type": "FGRCriterium",
-                    "fgrtype": "Noordzee"
+                    "wanted_fgrtype": "Noordzee"
                 },
                 {
                     "type": "FGRCriterium",
-                    "fgrtype": "Getijdengebied"
+                    "wanted_fgrtype": "Getijdengebied"
                 },
                 {
                     "type": "FGRCriterium",
-                    "fgrtype": "Duinen"
+                    "wanted_fgrtype": "Duinen"
                 },
                 {
                     "type": "NietGeautomatiseerd",
@@ -293,15 +293,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -323,15 +323,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -374,13 +374,13 @@
     },
     "mits in FGR Laagveengebied": {
         "type": "FGRCriterium",
-        "fgrtype": "Laagveengebied"
+        "wanted_fgrtype": "Laagveengebied"
     },
     "mits niet in hoogveen": {
         "type": "NietCriterium",
         "sub_criterium": {
             "type": "LBKCriterium",
-            "lbktype": "hoogveen"
+            "wanted_lbktype": "Hoogveen"
         }
     },
     "mits in FGR Hogere zandgronden zonder hoogveen": {
@@ -388,13 +388,13 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Hogere Zandgronden"
+                "wanted_fgrtype": "Hogere Zandgronden"
             },
             {
                 "type": "NietCriterium",
                 "sub_criterium": {
                     "type": "LBKCriterium",
-                    "lbktype": "hoogveen"
+                    "wanted_lbktype": "Hoogveen"
                 }
             }
         ]
@@ -407,15 +407,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -437,15 +437,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -464,7 +464,7 @@
         "sub_criteria": [
             {
                 "type": "LBKCriterium",
-                "lbktype": "hoogveenlandschap"
+                "wanted_lbktype": "Hoogveenlandschap"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -479,7 +479,7 @@
                 "type": "NietCriterium",
                 "sub_criterium": {
                     "type": "LBKCriterium",
-                    "lbktype": "hoogveenlandschap"
+                    "wanted_lbktype": "Hoogveenlandschap"
                 }
             },
             {
@@ -490,7 +490,7 @@
     },
     "mits in zandverstuiving": {
         "type": "LBKCriterium",
-        "lbktype": "zandverstuiving"
+        "wanted_lbktype": "Zandverstuiving"
     },
     "mits op oeverwallen van rivieren of riviertjes": {
         "type": "NietGeautomatiseerd",
@@ -504,15 +504,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -541,15 +541,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -571,15 +571,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -601,15 +601,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -639,15 +639,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -669,15 +669,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -705,15 +705,15 @@
                     "sub_criteria": [
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Noordzee"
+                            "wanted_fgrtype": "Noordzee"
                         },
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Getijdengebied"
+                            "wanted_fgrtype": "Getijdengebied"
                         },
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Duinen"
+                            "wanted_fgrtype": "Duinen"
                         },
                         {
                             "type": "NietGeautomatiseerd",
@@ -738,7 +738,7 @@
     },
     "mits in FGR Heuvelland": {
         "type": "FGRCriterium",
-        "fgrtype": "Heuvelland"
+        "wanted_fgrtype": "Heuvelland"
     },
     "mits een vlakvormig, al dan niet nabeweid, hooiland en niet in FGR Heuvelland": {
         "type": "EnCriteria",
@@ -747,7 +747,7 @@
                 "type": "NietCriterium",
                 "sub_criterium": {
                     "type": "FGRCriterium",
-                    "fgrtype": "Heuvelland"
+                    "wanted_fgrtype": "Heuvelland"
                 }
             },
             {
@@ -772,15 +772,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -804,15 +804,15 @@
                     "sub_criteria": [
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Noordzee"
+                            "wanted_fgrtype": "Noordzee"
                         },
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Getijdengebied"
+                            "wanted_fgrtype": "Getijdengebied"
                         },
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Duinen"
+                            "wanted_fgrtype": "Duinen"
                         },
                         {
                             "type": "NietGeautomatiseerd",
@@ -823,7 +823,7 @@
             },
             {
                 "type": "BodemCriterium",
-                "bodemtype": "vaaggronden"
+                "wanted_bodemtype": "Vaaggronden"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -841,15 +841,15 @@
                     "sub_criteria": [
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Noordzee"
+                            "wanted_fgrtype": "Noordzee"
                         },
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Getijdengebied"
+                            "wanted_fgrtype": "Getijdengebied"
                         },
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Duinen"
+                            "wanted_fgrtype": "Duinen"
                         },
                         {
                             "type": "NietGeautomatiseerd",
@@ -862,7 +862,7 @@
                 "type": "NietCriterium",
                 "sub_criterium": {
                     "type": "BodemCriterium",
-                    "bodemtype": "vaaggronden"
+                    "wanted_bodemtype": "Vaaggronden"
                 }
             },
             {
@@ -881,15 +881,15 @@
                     "sub_criteria": [
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Noordzee"
+                            "wanted_fgrtype": "Noordzee"
                         },
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Getijdengebied"
+                            "wanted_fgrtype": "Getijdengebied"
                         },
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Duinen"
+                            "wanted_fgrtype": "Duinen"
                         },
                         {
                             "type": "NietGeautomatiseerd",
@@ -909,7 +909,7 @@
         "sub_criteria": [
             {
                 "type": "BodemCriterium",
-                "bodemtype": "vaaggronden"
+                "wanted_bodemtype": "Vaaggronden"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -941,15 +941,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -971,15 +971,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -1006,11 +1006,11 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Duinen"
+                "wanted_fgrtype": "Duinen"
             },
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Getijdengebied"
+                "wanted_fgrtype": "Getijdengebied"
             }
         ]
     },
@@ -1022,15 +1022,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Laagveengebied"
+                        "wanted_fgrtype": "Laagveengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Zeekleigebied"
+                        "wanted_fgrtype": "Zeekleigebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Afgesloten Zeearmen"
+                        "wanted_fgrtype": "Afgesloten Zeearmen"
                     }
                 ]
             },
@@ -1057,7 +1057,7 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Duinen"
+                "wanted_fgrtype": "Duinen"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -1077,15 +1077,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -1108,13 +1108,13 @@
             },
             {
                 "type": "LBKCriterium",
-                "lbktype": "onder invloed van beek of rivier"
+                "wanted_lbktype": "Onder invloed van beek of rivier"
             }
         ]
     },
     "mits in FGR Duinen": {
         "type": "FGRCriterium",
-        "fgrtype": "Duinen"
+        "wanted_fgrtype": "Duinen"
     },
     "mits met veenmosbedekking > 20%": {
         "type": "NietGeautomatiseerd",
@@ -1131,7 +1131,7 @@
                 "type": "NietCriterium",
                 "sub_criterium": {
                     "type": "FGRCriterium",
-                    "fgrtype": "Duinen"
+                    "wanted_fgrtype": "Duinen"
                 }
             },
             {
@@ -1147,7 +1147,7 @@
                 "type": "NietCriterium",
                 "sub_criterium": {
                     "type": "FGRCriterium",
-                    "fgrtype": "Duinen"
+                    "wanted_fgrtype": "Duinen"
                 }
             },
             {
@@ -1164,15 +1164,15 @@
                 "sub_criteria": [
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "leemarme humuspodzolgronden"
+                        "wanted_bodemtype": "Leemarme humuspodzolgronden"
                     },
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "leemarme vaaggronden (H9190)"
+                        "wanted_bodemtype": "Leemarme vaaggronden (H9190)"
                     },
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "podzolgronden met een zanddek (H9190)"
+                        "wanted_bodemtype": "Podzolgronden met een zanddek (H9190)"
                     }
                 ]
             },
@@ -1184,7 +1184,7 @@
                 "type": "NietCriterium",
                 "sub_criterium": {
                     "type": "FGRCriterium",
-                    "fgrtype": "Duinen"
+                    "wanted_fgrtype": "Duinen"
                 }
             }
         ]
@@ -1197,19 +1197,19 @@
                 "sub_criteria": [
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "moderpodzolgronden"
+                        "wanted_bodemtype": "Moderpodzolgronden"
                     },
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "lemige humuspodzolgronden"
+                        "wanted_bodemtype": "Lemige humuspodzolgronden"
                     },
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "oude kleigronden"
+                        "wanted_bodemtype": "Oude kleigronden"
                     },
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "leemgronden"
+                        "wanted_bodemtype": "Leemgronden"
                     }
                 ]
             },
@@ -1221,21 +1221,21 @@
                 "type": "NietCriterium",
                 "sub_criterium": {
                     "type": "FGRCriterium",
-                    "fgrtype": "Duinen"
+                    "wanted_fgrtype": "Duinen"
                 }
             }
         ]
     },
     "mits in FGR Rivierengebied": {
         "type": "FGRCriterium",
-        "fgrtype": "Rivierengebied"
+        "wanted_fgrtype": "Rivierengebied"
     },
     "mits in FGR Duinen, op een standplaats als van andere vegetaties van H2180_A": {
         "type": "EnCriteria",
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Duinen"
+                "wanted_fgrtype": "Duinen"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -1248,7 +1248,7 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Duinen"
+                "wanted_fgrtype": "Duinen"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -1261,7 +1261,7 @@
         "sub_criteria": [
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Duinen"
+                "wanted_fgrtype": "Duinen"
             },
             {
                 "type": "NietGeautomatiseerd",
@@ -1271,7 +1271,7 @@
     },
     "mits in FGR Hogere zandgronden": {
         "type": "FGRCriterium",
-        "fgrtype": "Hogere Zandgronden"
+        "wanted_fgrtype": "Hogere Zandgronden"
     },
     "mits op moderpodzolgronden, lemige humuspodzolgronden, oude kleigronden of leemgronden zonder hydromorfe kenmerken en mits op een bosgroeiplaats ouder dan 1850 of in een daaraan grenzende minimaal honderdjarige bosopstand en mits niet in FGR Heuvelland of FGR Duinen": {
         "type": "EnCriteria",
@@ -1281,19 +1281,19 @@
                 "sub_criteria": [
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "moderpodzolgronden"
+                        "wanted_bodemtype": "Moderpodzolgronden"
                     },
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "lemige humuspodzolgronden"
+                        "wanted_bodemtype": "Lemige humuspodzolgronden"
                     },
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "oude kleigronden"
+                        "wanted_bodemtype": "Oude kleigronden"
                     },
                     {
                         "type": "BodemCriterium",
-                        "bodemtype": "leemgronden"
+                        "wanted_bodemtype": "Leemgronden"
                     }
                 ]
             },
@@ -1308,11 +1308,11 @@
                     "sub_criteria": [
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Heuvelland"
+                            "wanted_fgrtype": "Heuvelland"
                         },
                         {
                             "type": "FGRCriterium",
-                            "fgrtype": "Duinen"
+                            "wanted_fgrtype": "Duinen"
                         }
                     ]
                 }
@@ -1328,7 +1328,7 @@
             },
             {
                 "type": "FGRCriterium",
-                "fgrtype": "Hogere Zandgronden"
+                "wanted_fgrtype": "Hogere Zandgronden"
             }
         ]
     },
@@ -1352,15 +1352,15 @@
                 "sub_criteria": [
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Noordzee"
+                        "wanted_fgrtype": "Noordzee"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Getijdengebied"
+                        "wanted_fgrtype": "Getijdengebied"
                     },
                     {
                         "type": "FGRCriterium",
-                        "fgrtype": "Duinen"
+                        "wanted_fgrtype": "Duinen"
                     },
                     {
                         "type": "NietGeautomatiseerd",

--- a/notebooks/alle_karteringen_door_veg2hab.ipynb
+++ b/notebooks/alle_karteringen_door_veg2hab.ipynb
@@ -397,6 +397,7 @@
                 "    print(gebied)\n",
                 "    # Vervangen van de shapefile path naar de output path\n",
                 "    p = Path(overzicht[overzicht.naam_kartering == gebied].path_shapes.str.replace(opgeschoonde_shapefiles_prefix, output_prefix).iloc[0])\n",
+                "    p = p.with_suffix('.gpkg')\n",
                 "    p.parent.mkdir(parents=True, exist_ok=True)\n",
                 "    karteringen[gebied].final_format_to_file(p)\n"
             ]

--- a/notebooks/demo_criteria_opmerkingen.ipynb
+++ b/notebooks/demo_criteria_opmerkingen.ipynb
@@ -1,0 +1,370 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jordydelange/.cache/pypoetry/virtualenvs/veg2hab-CuqoUkZb-py3.7/lib/python3.7/site-packages/geopandas/_compat.py:115: UserWarning: The Shapely GEOS version (3.11.2-CAPI-1.17.2) is incompatible with the GEOS version PyGEOS was compiled with (3.10.4-CAPI-1.16.2). Conversions between both will be slow.\n",
+      "  shapely_geos_version, geos_capi_version_string\n"
+     ]
+    }
+   ],
+   "source": [
+    "from veg2hab.criteria import FGRCriterium, LBKCriterium, BodemCriterium, EnCriteria, NietCriterium, OfCriteria\n",
+    "from veg2hab.enums import FGRType, LBKType, BodemType, LBKTuple\n",
+    "import pandas as pd\n",
+    "from enum import Enum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "FGR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FGRType.DU\n",
+      "TRUE\n",
+      "{'FGR type is Duinen'}\n",
+      "--------\n",
+      "FGRType.HL\n",
+      "FALSE\n",
+      "{'FGR type is niet Duinen, maar Heuvelland'}\n",
+      "--------\n",
+      "<NA>\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit vlak ligt niet mooi binnen één FGR-vlak'}\n",
+      "--------\n"
+     ]
+    }
+   ],
+   "source": [
+    "du = FGRCriterium(wanted_fgrtype=FGRType.DU)\n",
+    "\n",
+    "for fgr_type in [FGRType.DU, FGRType.HL, pd.NA]:\n",
+    "    row = pd.Series({\"fgr\": fgr_type})\n",
+    "    du.check(row)\n",
+    "    print(fgr_type)\n",
+    "    print(du.evaluation)\n",
+    "    print(du.get_opm())\n",
+    "    print(\"--------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Bodemkaart met enkel negatieven"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Zn21']\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit is mogelijk leemarme vaaggronden want bodemcode Zn21'}\n",
+      "--------\n",
+      "['Abcd']\n",
+      "FALSE\n",
+      "{'Dit is niet leemarme vaaggronden want bodemcode Abcd'}\n",
+      "--------\n",
+      "[<NA>]\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak'}\n",
+      "--------\n"
+     ]
+    }
+   ],
+   "source": [
+    "lv = BodemCriterium(wanted_bodemtype=BodemType.LEEMARME_VAAGGRONDEN_H9190)\n",
+    "\n",
+    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], [pd.NA]]:\n",
+    "    row = pd.Series({\"bodem\": bodem_code})\n",
+    "    lv.check(row)\n",
+    "    print(bodem_code)\n",
+    "    print(lv.evaluation)\n",
+    "    print(lv.get_opm())\n",
+    "    print(\"--------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Bodemkaart met zowel positieven als negatieven"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Zn21']\n",
+      "TRUE\n",
+      "{'Dit is vaaggronden want bodemcode Zn21'}\n",
+      "--------\n",
+      "['Abcd']\n",
+      "FALSE\n",
+      "{'Dit is niet vaaggronden want bodemcode Abcd'}\n",
+      "--------\n",
+      "[<NA>]\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak'}\n",
+      "--------\n"
+     ]
+    }
+   ],
+   "source": [
+    "vg = BodemCriterium(wanted_bodemtype=BodemType.VAAGGRONDEN)\n",
+    "\n",
+    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], [pd.NA]]:\n",
+    "    row = pd.Series({\"bodem\": bodem_code})\n",
+    "    vg.check(row)\n",
+    "    print(bodem_code)\n",
+    "    print(vg.evaluation)\n",
+    "    print(vg.get_opm())\n",
+    "    print(\"--------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "LBK met enkel negatieven"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HzHL\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit is mogelijk herstellend hoogveen want LBK code HzHL'}\n",
+      "--------\n",
+      "Abcd\n",
+      "FALSE\n",
+      "{'Dit is niet herstellend hoogveen want LBK code Abcd'}\n",
+      "--------\n",
+      "<NA>\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit vlak ligt niet mooi binnen één LBK-vak'}\n",
+      "--------\n"
+     ]
+    }
+   ],
+   "source": [
+    "hh = LBKCriterium(wanted_lbktype=LBKType.HERSTELLEND_HOOGVEEN)\n",
+    "\n",
+    "for lbk_code in [\"HzHL\", \"Abcd\", pd.NA]:\n",
+    "    row = pd.Series({\"lbk\": lbk_code})\n",
+    "    hh.check(row)\n",
+    "    print(lbk_code)\n",
+    "    print(hh.evaluation)\n",
+    "    print(hh.get_opm())\n",
+    "    print(\"--------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "LBK met enkel positieven"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HzHL\n",
+      "TRUE\n",
+      "{'Dit is hoogveenlandschap want LBK code HzHL'}\n",
+      "--------\n",
+      "Abcd\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit is mogelijk toch hoogveenlandschap ondanks LBK code Abcd'}\n",
+      "--------\n",
+      "<NA>\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit vlak ligt niet mooi binnen één LBK-vak'}\n",
+      "--------\n"
+     ]
+    }
+   ],
+   "source": [
+    "hl = LBKCriterium(wanted_lbktype=LBKType.HOOGVEENLANDSCHAP)\n",
+    "\n",
+    "for lbk_code in [\"HzHL\", \"Abcd\", pd.NA]:\n",
+    "    row = pd.Series({\"lbk\": lbk_code})\n",
+    "    hl.check(row)\n",
+    "    print(lbk_code)\n",
+    "    print(hl.evaluation)\n",
+    "    print(hl.get_opm())\n",
+    "    print(\"--------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Demo voor een mogelijke LBK met zowel positieven als negatieven"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "demo\n",
+      "TRUE\n",
+      "{'Dit is demo_zowel_positief_als_negatief want LBK code demo'}\n",
+      "--------\n",
+      "Abcd\n",
+      "FALSE\n",
+      "{'Dit is niet demo_zowel_positief_als_negatief want LBK code Abcd'}\n",
+      "--------\n",
+      "<NA>\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit vlak ligt niet mooi binnen één LBK-vak'}\n",
+      "--------\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_lbk = LBKCriterium(wanted_lbktype=LBKType.DEMO_ZOWEL_POSITIEF_ALS_NEGATIEF)\n",
+    "\n",
+    "for lbk_code in [\"demo\", \"Abcd\", pd.NA]:\n",
+    "    row = pd.Series({\"lbk\": lbk_code})\n",
+    "    new_lbk.check(row)\n",
+    "    print(lbk_code)\n",
+    "    print(new_lbk.evaluation)\n",
+    "    print(new_lbk.get_opm())\n",
+    "    print(\"--------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Combineren"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "((LBK is herstellend hoogveen (C) of LBK is hoogveenlandschap (T) of Bodem is leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (F))\n",
+      "TRUE\n",
+      "Dit is hoogveenlandschap want LBK code HzHL\n",
+      "Dit is mogelijk herstellend hoogveen want LBK code HzHL\n",
+      "Dit is niet leemarme humuspodzolgronden want bodemcode Zn21\n",
+      "FGR type is niet Laagveengebied, maar Duinen\n",
+      "--------\n",
+      "((LBK is herstellend hoogveen (F) of LBK is hoogveenlandschap (C) of Bodem is leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (T))\n",
+      "FALSE\n",
+      "Dit is niet leemarme humuspodzolgronden want bodemcode Abcd\n",
+      "Dit is mogelijk toch hoogveenlandschap ondanks LBK code Abcd\n",
+      "Dit is niet herstellend hoogveen want LBK code Abcd\n",
+      "FGR type is Laagveengebied\n",
+      "--------\n",
+      "((LBK is herstellend hoogveen (C) of LBK is hoogveenlandschap (C) of Bodem is leemarme humuspodzolgronden (C)) en niet FGR is Laagveengebied (C))\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "Dit vlak ligt niet mooi binnen één bodemkaartvlak\n",
+      "Dit vlak ligt niet mooi binnen één FGR-vlak\n",
+      "Dit vlak ligt niet mooi binnen één LBK-vak\n",
+      "--------\n"
+     ]
+    }
+   ],
+   "source": [
+    "crit = EnCriteria(\n",
+    "    sub_criteria=\n",
+    "    [\n",
+    "        OfCriteria(\n",
+    "            sub_criteria=\n",
+    "            [\n",
+    "                LBKCriterium(wanted_lbktype=LBKType.HERSTELLEND_HOOGVEEN),\n",
+    "                LBKCriterium(wanted_lbktype=LBKType.HOOGVEENLANDSCHAP),\n",
+    "                BodemCriterium(wanted_bodemtype=BodemType.LEEMARME_HUMUSPODZOLGRONDEN),\n",
+    "            ]), \n",
+    "        NietCriterium(\n",
+    "            sub_criterium=FGRCriterium(wanted_fgrtype=FGRType.LV)\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "for lbk_code, fgr_code, bodem_code in [(\"HzHL\", FGRType.DU, [\"Zn21\"]), (\"Abcd\", FGRType.LV, [\"Abcd\"]), (pd.NA, pd.NA, [pd.NA])]:\n",
+    "    row = pd.Series({\"lbk\": lbk_code, \"fgr\": fgr_code, \"bodem\": bodem_code})\n",
+    "    crit.check(row)\n",
+    "    print(str(crit))\n",
+    "    print(crit.evaluation)\n",
+    "    for sentence in crit.get_opm():\n",
+    "        print(sentence)\n",
+    "    print(\"--------\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "veg2hab-CuqoUkZb-py3.7",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/demo_criteria_opmerkingen.ipynb
+++ b/notebooks/demo_criteria_opmerkingen.ipynb
@@ -39,15 +39,15 @@
      "text": [
       "FGRType.DU\n",
       "TRUE\n",
-      "{'FGR type is Duinen'}\n",
+      "{'FGR type is Duinen.'}\n",
       "--------\n",
       "FGRType.HL\n",
       "FALSE\n",
-      "{'FGR type is niet Duinen, maar Heuvelland'}\n",
+      "{'FGR type is niet Duinen, maar Heuvelland.'}\n",
       "--------\n",
       "<NA>\n",
       "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één FGR-vlak'}\n",
+      "{'Dit vlak ligt niet mooi binnen één FGR-vlak.'}\n",
       "--------\n"
      ]
     }
@@ -82,15 +82,15 @@
      "text": [
       "['Zn21']\n",
       "CANNOT_BE_AUTOMATED\n",
-      "{'Dit is mogelijk leemarme vaaggronden want bodemcode Zn21'}\n",
+      "{'Dit is mogelijk Leemarme vaaggronden want bodemcode Zn21.'}\n",
       "--------\n",
       "['Abcd']\n",
       "FALSE\n",
-      "{'Dit is niet leemarme vaaggronden want bodemcode Abcd'}\n",
+      "{'Dit is niet Leemarme vaaggronden want bodemcode Abcd.'}\n",
       "--------\n",
       "[<NA>]\n",
       "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak'}\n",
+      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak.'}\n",
       "--------\n"
      ]
     }
@@ -125,15 +125,15 @@
      "text": [
       "['Zn21']\n",
       "TRUE\n",
-      "{'Dit is vaaggronden want bodemcode Zn21'}\n",
+      "{'Dit is Vaaggronden want bodemcode Zn21.'}\n",
       "--------\n",
       "['Abcd']\n",
       "FALSE\n",
-      "{'Dit is niet vaaggronden want bodemcode Abcd'}\n",
+      "{'Dit is niet Vaaggronden want bodemcode Abcd.'}\n",
       "--------\n",
       "[<NA>]\n",
       "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak'}\n",
+      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak.'}\n",
       "--------\n"
      ]
     }
@@ -168,11 +168,11 @@
      "text": [
       "HzHL\n",
       "CANNOT_BE_AUTOMATED\n",
-      "{'Dit is mogelijk herstellend hoogveen want LBK code HzHL'}\n",
+      "{'Dit is mogelijk Herstellend hoogveen want LBK code HzHL.'}\n",
       "--------\n",
       "Abcd\n",
       "FALSE\n",
-      "{'Dit is niet herstellend hoogveen want LBK code Abcd'}\n",
+      "{'Dit is niet Herstellend hoogveen want LBK code Abcd.'}\n",
       "--------\n",
       "<NA>\n",
       "CANNOT_BE_AUTOMATED\n",
@@ -211,11 +211,11 @@
      "text": [
       "HzHL\n",
       "TRUE\n",
-      "{'Dit is hoogveenlandschap want LBK code HzHL'}\n",
+      "{'Dit is Hoogveenlandschap want LBK code HzHL.'}\n",
       "--------\n",
       "Abcd\n",
       "CANNOT_BE_AUTOMATED\n",
-      "{'Dit is mogelijk toch hoogveenlandschap ondanks LBK code Abcd'}\n",
+      "{'Dit is mogelijk toch Hoogveenlandschap ondanks LBK code Abcd.'}\n",
       "--------\n",
       "<NA>\n",
       "CANNOT_BE_AUTOMATED\n",
@@ -240,7 +240,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Demo voor een mogelijke LBK met zowel positieven als negatieven"
+    "Combineren"
    ]
   },
   {
@@ -252,67 +252,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "demo\n",
+      "((LBK is Herstellend hoogveen (C) of LBK is Hoogveenlandschap (T) of Bodem is Leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (F))\n",
       "TRUE\n",
-      "{'Dit is demo_zowel_positief_als_negatief want LBK code demo'}\n",
+      "Dit is Hoogveenlandschap want LBK code HzHL.\n",
+      "FGR type is niet Laagveengebied, maar Duinen.\n",
+      "Dit is niet Leemarme humuspodzolgronden want bodemcode Zn21.\n",
+      "Dit is mogelijk Herstellend hoogveen want LBK code HzHL.\n",
       "--------\n",
-      "Abcd\n",
+      "((LBK is Herstellend hoogveen (F) of LBK is Hoogveenlandschap (C) of Bodem is Leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (T))\n",
       "FALSE\n",
-      "{'Dit is niet demo_zowel_positief_als_negatief want LBK code Abcd'}\n",
+      "Dit is niet Herstellend hoogveen want LBK code Abcd.\n",
+      "Dit is mogelijk toch Hoogveenlandschap ondanks LBK code Abcd.\n",
+      "Dit is niet Leemarme humuspodzolgronden want bodemcode Abcd.\n",
+      "FGR type is Laagveengebied.\n",
       "--------\n",
-      "<NA>\n",
+      "((LBK is Herstellend hoogveen (C) of LBK is Hoogveenlandschap (C) of Bodem is Leemarme humuspodzolgronden (C)) en niet FGR is Laagveengebied (C))\n",
       "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één LBK-vak'}\n",
-      "--------\n"
-     ]
-    }
-   ],
-   "source": [
-    "new_lbk = LBKCriterium(wanted_lbktype=LBKType.DEMO_ZOWEL_POSITIEF_ALS_NEGATIEF)\n",
-    "\n",
-    "for lbk_code in [\"demo\", \"Abcd\", pd.NA]:\n",
-    "    row = pd.Series({\"lbk\": lbk_code})\n",
-    "    new_lbk.check(row)\n",
-    "    print(lbk_code)\n",
-    "    print(new_lbk.evaluation)\n",
-    "    print(new_lbk.get_opm())\n",
-    "    print(\"--------\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Combineren"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "((LBK is herstellend hoogveen (C) of LBK is hoogveenlandschap (T) of Bodem is leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (F))\n",
-      "TRUE\n",
-      "Dit is hoogveenlandschap want LBK code HzHL\n",
-      "Dit is mogelijk herstellend hoogveen want LBK code HzHL\n",
-      "Dit is niet leemarme humuspodzolgronden want bodemcode Zn21\n",
-      "FGR type is niet Laagveengebied, maar Duinen\n",
-      "--------\n",
-      "((LBK is herstellend hoogveen (F) of LBK is hoogveenlandschap (C) of Bodem is leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (T))\n",
-      "FALSE\n",
-      "Dit is niet leemarme humuspodzolgronden want bodemcode Abcd\n",
-      "Dit is mogelijk toch hoogveenlandschap ondanks LBK code Abcd\n",
-      "Dit is niet herstellend hoogveen want LBK code Abcd\n",
-      "FGR type is Laagveengebied\n",
-      "--------\n",
-      "((LBK is herstellend hoogveen (C) of LBK is hoogveenlandschap (C) of Bodem is leemarme humuspodzolgronden (C)) en niet FGR is Laagveengebied (C))\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "Dit vlak ligt niet mooi binnen één bodemkaartvlak\n",
-      "Dit vlak ligt niet mooi binnen één FGR-vlak\n",
+      "Dit vlak ligt niet mooi binnen één FGR-vlak.\n",
+      "Dit vlak ligt niet mooi binnen één bodemkaartvlak.\n",
       "Dit vlak ligt niet mooi binnen één LBK-vak\n",
       "--------\n"
      ]

--- a/notebooks/functionality_test.ipynb
+++ b/notebooks/functionality_test.ipynb
@@ -212,12 +212,19 @@
             ]
         },
         {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Functionele samenhang"
+            ]
+        },
+        {
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
             "outputs": [],
             "source": [
-                "access_kartering.gdf.head()"
+                "access_kartering.functionele_samenhang()"
             ]
         },
         {
@@ -238,15 +245,6 @@
             "outputs": [],
             "source": [
                 "final_format = access_kartering.as_final_format()\n",
-                "final_format"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
                 "final_format"
             ]
         },

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -1,0 +1,135 @@
+import pandas as pd
+import pytest
+
+from veg2hab.criteria import (
+    BodemCriterium,
+    EnCriteria,
+    FGRCriterium,
+    LBKCriterium,
+    NietCriterium,
+    NietGeautomatiseerdCriterium,
+    OfCriteria,
+)
+from veg2hab.enums import BodemType, FGRType, LBKType, MaybeBoolean
+
+# For "tests" of criteria.get_opm, please see demo_criteria_opmerkingen.py
+
+
+def test_FGRCriterium():
+    crit = FGRCriterium(wanted_fgrtype=FGRType.DU)
+    assert crit.wanted_fgrtype == FGRType.DU
+    row = pd.Series({"fgr": FGRType.DU})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.TRUE
+    row = pd.Series({"fgr": FGRType.LV})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+
+
+def test_LBKCriterium_enkel_negatieven():
+    crit = LBKCriterium(wanted_lbktype=LBKType.HOOGVEEN)
+    assert crit.wanted_lbktype == LBKType.HOOGVEEN
+    row = pd.Series({"lbk": "HzHL"})
+    crit.check(row)
+    assert crit.wanted_lbktype.enkel_negatieven == True
+    assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+    row = pd.Series({"lbk": "Abcd"})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+
+
+def test_LBKCriterium_enkel_positieven():
+    crit = LBKCriterium(wanted_lbktype=LBKType.HOOGVEENLANDSCHAP)
+    assert crit.wanted_lbktype == LBKType.HOOGVEENLANDSCHAP
+    row = pd.Series({"lbk": "HzHL"})
+    crit.check(row)
+    assert crit.wanted_lbktype.enkel_positieven == True
+    assert crit.evaluation == MaybeBoolean.TRUE
+    row = pd.Series({"lbk": "Abcd"})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+
+
+def test_BodemCriterium_normaal():
+    crit = BodemCriterium(wanted_bodemtype=BodemType.LEEMARME_HUMUSPODZOLGRONDEN)
+    assert crit.wanted_bodemtype == BodemType.LEEMARME_HUMUSPODZOLGRONDEN
+    row = pd.Series({"bodem": ["Hn21"]})
+    crit.check(row)
+    assert crit.wanted_bodemtype.enkel_negatieven == False
+    assert crit.evaluation == MaybeBoolean.TRUE
+    row = pd.Series({"bodem": ["Abcd"]})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+    row = pd.Series({"bodem": ["Abcd", "Hn21"]})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+
+
+def test_BodemCriterium_enkel_negatieven():
+    crit = BodemCriterium(wanted_bodemtype=BodemType.LEEMARME_VAAGGRONDEN_H9190)
+    assert crit.wanted_bodemtype == BodemType.LEEMARME_VAAGGRONDEN_H9190
+    row = pd.Series({"bodem": ["Zn21"]})
+    crit.check(row)
+    assert crit.wanted_bodemtype.enkel_negatieven == True
+    assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+    row = pd.Series({"bodem": ["Abcd"]})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+
+
+def test_EnCriteria():
+    crit = EnCriteria(
+        sub_criteria=[
+            FGRCriterium(wanted_fgrtype=FGRType.DU),
+            FGRCriterium(wanted_fgrtype=FGRType.LV),
+        ]
+    )
+    row = pd.Series({"fgr": FGRType.DU})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+    crit = EnCriteria(
+        sub_criteria=[
+            FGRCriterium(wanted_fgrtype=FGRType.DU),
+            FGRCriterium(wanted_fgrtype=FGRType.DU),
+        ]
+    )
+    row = pd.Series({"fgr": FGRType.DU})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.TRUE
+
+
+def test_OfCriteria():
+    crit = OfCriteria(
+        sub_criteria=[
+            FGRCriterium(wanted_fgrtype=FGRType.DU),
+            FGRCriterium(wanted_fgrtype=FGRType.LV),
+        ]
+    )
+    row = pd.Series({"fgr": FGRType.DU})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.TRUE
+    crit = OfCriteria(
+        sub_criteria=[
+            FGRCriterium(wanted_fgrtype=FGRType.DU),
+            FGRCriterium(wanted_fgrtype=FGRType.DU),
+        ]
+    )
+    row = pd.Series({"fgr": FGRType.LV})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+
+
+def test_NietCriterium():
+    crit = NietCriterium(sub_criterium=FGRCriterium(wanted_fgrtype=FGRType.DU))
+    row = pd.Series({"fgr": FGRType.DU})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+    row = pd.Series({"fgr": FGRType.LV})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.TRUE
+
+
+def test_NietGeautomatiseerdCriterium():
+    crit = NietGeautomatiseerdCriterium(toelichting="test")
+    crit.check(pd.Series())
+    assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED

--- a/tests/test_deftabel_matching.py
+++ b/tests/test_deftabel_matching.py
@@ -48,9 +48,9 @@ def test_perfect_match_VvN(dt):
             idx_in_dt=31,
             mits=OfCriteria(
                 sub_criteria=[
-                    FGRCriterium(fgrtype=FGRType.NZ),
-                    FGRCriterium(fgrtype=FGRType.GG),
-                    FGRCriterium(fgrtype=FGRType.DU),
+                    FGRCriterium(wanted_fgrtype=FGRType.NZ),
+                    FGRCriterium(wanted_fgrtype=FGRType.GG),
+                    FGRCriterium(wanted_fgrtype=FGRType.DU),
                     NietGeautomatiseerdCriterium(
                         toelichting='het vlak op andere wijze onder "kustgebied" valt'
                     ),
@@ -128,7 +128,7 @@ def test_match_to_multiple_perfect_matches_VvN(dt):
             habtype="H2330",
             kwaliteit=Kwaliteit.GOED,
             idx_in_dt=276,
-            mits=LBKCriterium(lbktype=LBKType.ZANDVERSTUIVING),
+            mits=LBKCriterium(wanted_lbktype=LBKType.ZANDVERSTUIVING),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.SUBASSOCIATIE_VVN,
         ),
@@ -160,7 +160,7 @@ def test_perfect_and_less_specific_match_VvN(dt):
             idx_in_dt=169,
             mits=EnCriteria(
                 sub_criteria=[
-                    FGRCriterium(fgrtype=FGRType.DU),
+                    FGRCriterium(wanted_fgrtype=FGRType.DU),
                     NietGeautomatiseerdCriterium(toelichting="zachte berk dominant"),
                 ]
             ),
@@ -227,7 +227,7 @@ def test_matches_both_vvn_and_sbb(dt):
             habtype="H2330",
             kwaliteit=Kwaliteit.GOED,
             idx_in_dt=276,
-            mits=LBKCriterium(lbktype=LBKType.ZANDVERSTUIVING),
+            mits=LBKCriterium(wanted_lbktype=LBKType.ZANDVERSTUIVING),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.SUBASSOCIATIE_VVN,
         ),

--- a/veg2hab/bronnen.py
+++ b/veg2hab/bronnen.py
@@ -15,7 +15,8 @@ from veg2hab.enums import FGRType
 #       binnen een bronvlak liggen NaN krijgen. Beter zou zijn dat ze alles krijgen waar ze op liggen, en als
 #       dat steeds dezelfde is, het karteringvlak alsnog dat type krijgt. Dit kan voorkomen bij LBK en bij
 #       de bodemkaart, omdat hier regelmatig vlakken met dezelfde typering toch naast elkaar liggen, omdat ze
-#       verschillen in zaken waar wij niet naar kijken.
+#       verschillen in zaken waar wij niet naar kijken. Het kan ook zijn dat 1 vlak in 2 bronvlakken ligt, en
+#       dat beide bronvlakken andere typeringen hebben die toch onder dezelfde categorie vallen.
 
 
 def get_checksum(path: Path) -> str:

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -180,8 +180,11 @@ class BodemCriterium(BeperkendCriterium):
                 self._evaluation = MaybeBoolean.TRUE
                 break
 
-        if self.wanted_bodemtype.enkel_negatieven and self.evaluation == MaybeBoolean.TRUE:
-                self._evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
+        if (
+            self.wanted_bodemtype.enkel_negatieven
+            and self.evaluation == MaybeBoolean.TRUE
+        ):
+            self._evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
 
     def __str__(self):
         string = f"Bodem is {self.wanted_bodemtype}"

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -136,6 +136,7 @@ class FGRCriterium(BeperkendCriterium):
             logging.warning(
                 "Er wordt om opmerking-strings gevraagd voordat de mits is gecheckt."
             )
+            return set()
 
         if pd.isna(self.actual_fgrtype):
             return {"Dit vlak ligt niet mooi binnen één FGR-vlak."}
@@ -179,8 +180,7 @@ class BodemCriterium(BeperkendCriterium):
                 self._evaluation = MaybeBoolean.TRUE
                 break
 
-        if self.wanted_bodemtype.enkel_negatieven:
-            if self.evaluation == MaybeBoolean.TRUE:
+        if self.wanted_bodemtype.enkel_negatieven and self.evaluation == MaybeBoolean.TRUE:
                 self._evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
 
     def __str__(self):

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -1,8 +1,9 @@
 import json
+import logging
 from functools import reduce
 from itertools import chain
 from operator import and_, or_
-from typing import ClassVar, List, Optional, Union
+from typing import ClassVar, List, Optional, Set, Union
 
 import geopandas as gpd
 import pandas as pd
@@ -57,8 +58,8 @@ class BeperkendCriterium(BaseModel):
     def is_criteria_type_present(self, type):
         return isinstance(self, type)
 
-    def get_opm(self) -> str:
-        return None
+    def get_opm(self) -> Set[str]:
+        raise NotImplementedError()
 
     @property
     def evaluation(self) -> MaybeBoolean:
@@ -82,6 +83,9 @@ class GeenCriterium(BeperkendCriterium):
     def __str__(self):
         return "Geen mits (altijd waar)"
 
+    def get_opm(self) -> Set[str]:
+        return set()
+
 
 class NietGeautomatiseerdCriterium(BeperkendCriterium):
     type: ClassVar[str] = "NietGeautomatiseerd"
@@ -94,15 +98,21 @@ class NietGeautomatiseerdCriterium(BeperkendCriterium):
     def __str__(self):
         return f"(Niet geautomatiseerd: {self.toelichting})"
 
+    def get_opm(self) -> Set[str]:
+        return set()
+
 
 class FGRCriterium(BeperkendCriterium):
     type: ClassVar[str] = "FGRCriterium"
-    fgrtype: FGRType
+    wanted_fgrtype: FGRType
+    actual_fgrtype: Optional[FGRType] = None
     _evaluation: Optional[MaybeBoolean] = PrivateAttr(default=None)
 
     def check(self, row: gpd.GeoSeries) -> None:
         assert "fgr" in row, "fgr kolom niet aanwezig"
         assert row["fgr"] is not None, "fgr kolom is leeg"
+
+        self.actual_fgrtype = row["fgr"]
 
         if pd.isna(row["fgr"]):
             # Er is een NaN als het vlak niet mooi binnen een FGR vlak valt
@@ -110,32 +120,48 @@ class FGRCriterium(BeperkendCriterium):
             return
 
         self._evaluation = (
-            MaybeBoolean.TRUE if row["fgr"] == self.fgrtype else MaybeBoolean.FALSE
+            MaybeBoolean.TRUE
+            if row["fgr"] == self.wanted_fgrtype
+            else MaybeBoolean.FALSE
         )
 
     def __str__(self):
-        string = f"FGR is {self.fgrtype.value}"
+        string = f"FGR is {self.wanted_fgrtype.value}"
         if self._evaluation is not None:
             string += f" ({self._evaluation.as_letter()})"
         return string
 
-    # def get_opm(self) -> str:
-    #     if pd.isna(self.fgrtype):
-    #         return "vlak ligt niet binnen een FGR-vak"
-    #     return f"FGR type is {self.fgrtype.value}"
+    def get_opm(self) -> Set[str]:
+        if self._evaluation is None:
+            logging.warning(
+                "Er wordt om opmerking-strings gevraagd voordat de mits is gecheckt."
+            )
+
+        if pd.isna(self.actual_fgrtype):
+            return {"Dit vlak ligt niet mooi binnen één FGR-vlak."}
+        framework = "FGR type is {}{}{}."
+        return {
+            framework.format(
+                "niet " if self._evaluation == MaybeBoolean.FALSE else "",
+                self.wanted_fgrtype.value,
+                ", maar " + self.actual_fgrtype.value
+                if self._evaluation == MaybeBoolean.FALSE
+                else "",
+            )
+        }
 
 
 class BodemCriterium(BeperkendCriterium):
     type: ClassVar[str] = "BodemCriterium"
-    bodemtype: BodemType
-    # actual_bodemtype: List[str]
+    wanted_bodemtype: BodemType
+    actual_bodemcode: List[Optional[str]] = [None]
     _evaluation: Optional[MaybeBoolean] = PrivateAttr(default=None)
 
     def check(self, row: gpd.GeoSeries) -> None:
         assert "bodem" in row, "bodem kolom niet aanwezig"
-        assert row["bodem"] is not None, "bodem kolom is leeg"
+        assert isinstance(row["bodem"], list), "bodem kolom moet een list zijn"
 
-        # self.actual_bodemtype = row["bodem"]
+        self.actual_bodemcode = row["bodem"]
 
         if len(row["bodem"]) > 1:
             # Vlak heeft meerdere bodemtypen, kunnen we niet automatiseren
@@ -147,32 +173,60 @@ class BodemCriterium(BeperkendCriterium):
             self._evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
             return
 
-        self._evaluation = (
-            MaybeBoolean.TRUE if row["bodem"] == self.bodemtype else MaybeBoolean.FALSE
-        )
+        self._evaluation = MaybeBoolean.FALSE
+        for code in row["bodem"]:
+            if code in self.wanted_bodemtype.codes:
+                self._evaluation = MaybeBoolean.TRUE
+                break
+
+        if self.wanted_bodemtype.enkel_negatieven:
+            if self.evaluation == MaybeBoolean.TRUE:
+                self._evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
 
     def __str__(self):
-        string = f"Bodem is {self.bodemtype}"
+        string = f"Bodem is {self.wanted_bodemtype}"
         if self._evaluation is not None:
             string += f" ({self._evaluation.as_letter()})"
         return string
 
-    # def get_opm(self) -> str:
-    #     if len(self.actual_bodemtype) == 1:
-    #         if pd.isna(self.actual_bodemtype[0]):
-    #             return "vlak ligt niet binnen een bodemkaartvlak"
-    #         return f"bodemtype is {self.actual_bodemtype[0]}"
-    #     return f"bodemtypen zijn {', '.join(self.actual_bodemtype)}"
+    def get_opm(self) -> Set[str]:
+        if self._evaluation is None:
+            logging.warning(
+                "Er wordt om opmerking-strings gevraagd voordat de mits is gecheckt."
+            )
+
+        if len(self.actual_bodemcode) == 1:
+            if pd.isna(self.actual_bodemcode[0]):
+                return {"Dit vlak ligt niet mooi binnen één bodemkaartvlak."}
+
+        framework = (
+            "Dit is {}{}"
+            + str(self.wanted_bodemtype)
+            + " want bodemcode "
+            + ", ".join(self.actual_bodemcode)
+            + "."
+        )
+        return {
+            framework.format(
+                "mogelijk "
+                if self._evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+                else "",
+                "niet " if self._evaluation == MaybeBoolean.FALSE else "",
+            )
+        }
 
 
 class LBKCriterium(BeperkendCriterium):
     type: ClassVar[str] = "LBKCriterium"
-    lbktype: LBKType
+    wanted_lbktype: LBKType
+    actual_lbkcode: Optional[str] = None
     _evaluation: Optional[MaybeBoolean] = PrivateAttr(default=None)
 
     def check(self, row: gpd.GeoSeries) -> None:
         assert "lbk" in row, "lbk kolom niet aanwezig"
         assert row["lbk"] is not None, "lbk kolom is leeg"
+
+        self.actual_lbkcode = row["lbk"]
 
         if pd.isna(row["lbk"]):
             # Er is een NaN als het vlak niet mooi binnen een LBK vak valt
@@ -180,19 +234,65 @@ class LBKCriterium(BeperkendCriterium):
             return
 
         self._evaluation = (
-            MaybeBoolean.TRUE if row["lbk"] == self.lbktype else MaybeBoolean.FALSE
+            MaybeBoolean.TRUE
+            if row["lbk"] in self.wanted_lbktype.codes
+            else MaybeBoolean.FALSE
         )
 
+        if self.wanted_lbktype.enkel_negatieven:
+            if self.evaluation == MaybeBoolean.TRUE:
+                self._evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
+
+        if self.wanted_lbktype.enkel_positieven:
+            if self.evaluation == MaybeBoolean.FALSE:
+                self._evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
+
     def __str__(self):
-        string = f"LBK is {self.lbktype}"
+        string = f"LBK is {self.wanted_lbktype}"
         if self._evaluation is not None:
             string += f" ({self._evaluation.as_letter()})"
         return string
 
-    # def get_opm(self) -> str:
-    #     if pd.isna(self.lbktype):
-    #         return "vlak ligt niet binnen een LBK-vak"
-    #     return f"LBK type is {self.lbktype.value}"
+    def get_opm(self) -> Set[str]:
+        assert (
+            self._evaluation is not MaybeBoolean.POSTPONE
+        ), "Postpone is not a valid evaluation state for LBKCriterium"
+        if self._evaluation is None:
+            print("test")
+            logging.warning(
+                "Er wordt om opmerking-strings gevraagd voordat de mits is gecheckt."
+            )
+
+        if pd.isna(self.actual_lbkcode):
+            return {"Dit vlak ligt niet mooi binnen één LBK-vak"}
+
+        framework = (
+            "Dit is {}{}{}"
+            + str(self.wanted_lbktype)
+            + " {}LBK code "
+            + str(self.actual_lbkcode)
+            + "."
+        )
+        return {
+            framework.format(
+                "mogelijk "
+                if self._evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+                else "",
+                "toch "
+                if (
+                    self._evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+                    and self.wanted_lbktype.enkel_positieven
+                )
+                else "",
+                "niet " if self._evaluation == MaybeBoolean.FALSE else "",
+                "ondanks "
+                if (
+                    self._evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+                    and self.wanted_lbktype.enkel_positieven
+                )
+                else "want ",
+            )
+        }
 
 
 class NietCriterium(BeperkendCriterium):
@@ -214,8 +314,8 @@ class NietCriterium(BeperkendCriterium):
     def __str__(self):
         return f"niet {self.sub_criterium}"
 
-    # def get_opm(self) -> str:
-    #     return self.sub_criterium.get_opm()
+    def get_opm(self) -> Set[str]:
+        return self.sub_criterium.get_opm()
 
 
 class OfCriteria(BeperkendCriterium):
@@ -245,11 +345,8 @@ class OfCriteria(BeperkendCriterium):
         of_crits = " of ".join(str(crit) for crit in self.sub_criteria)
         return f"({of_crits})"
 
-    # def get_opm(self) -> str:
-    #     opms = [crit.get_opm() for crit in self.sub_criteria]
-    #     # remove duplicates and None values
-    #     opms = list(set(filter(None, opms)))
-    #     return ", ".join(opms)
+    def get_opm(self) -> Set[str]:
+        return set.union(*[crit.get_opm() for crit in self.sub_criteria])
 
 
 class EnCriteria(BeperkendCriterium):
@@ -278,11 +375,8 @@ class EnCriteria(BeperkendCriterium):
         en_crits = " en ".join(str(crit) for crit in self.sub_criteria)
         return f"({en_crits})"
 
-    # def get_opm(self) -> str:
-    #     opms = [crit.get_opm() for crit in self.sub_criteria]
-    #     # remove duplicates and None values
-    #     opms = list(set(filter(None, opms)))
-    #     return ", ".join(opms)
+    def get_opm(self) -> Set[str]:
+        return set.union(*[crit.get_opm() for crit in self.sub_criteria])
 
 
 def is_criteria_type_present(

--- a/veg2hab/enums.py
+++ b/veg2hab/enums.py
@@ -200,20 +200,20 @@ class BodemType(Enum):
         - Is dit type sluitend of is het enkel voor negatieven?
     """
 
-    LEEMARME_HUMUSPODZOLGRONDEN = "leemarme humuspodzolgronden"
-    LEMIGE_HUMUSPODZOLGRONDEN = "lemige humuspodzolgronden"
-    VAAGGRONDEN = "vaaggronden"
-    LEEMARME_VAAGGRONDEN_H9190 = "leemarme vaaggronden (H9190)"
-    PODZOLGRONDEN_MET_EEN_ZANDDEK_H9190 = "podzolgronden met een zanddek (H9190)"
-    MODERPODZOLGRONDEN = "moderpodzolgronden"
-    OUDE_KLEIGRONDEN = "oude kleigronden"
-    LEEMGRONDEN = "leemgronden"
+    LEEMARME_HUMUSPODZOLGRONDEN = "Leemarme humuspodzolgronden"
+    LEMIGE_HUMUSPODZOLGRONDEN = "Lemige humuspodzolgronden"
+    VAAGGRONDEN = "Vaaggronden"
+    LEEMARME_VAAGGRONDEN_H9190 = "Leemarme vaaggronden (H9190)"
+    PODZOLGRONDEN_MET_EEN_ZANDDEK_H9190 = "Podzolgronden met een zanddek (H9190)"
+    MODERPODZOLGRONDEN = "Moderpodzolgronden"
+    OUDE_KLEIGRONDEN = "Oude kleigronden"
+    LEEMGRONDEN = "Leemgronden"
 
     # TODO: Misschien een "enkel_bij_habtype" veld in te tuple om de 2 H9190 specifieke te forceren?
 
     _tuple_dict = {
         "LEEMARME_HUMUSPODZOLGRONDEN": BodemTuple(
-            string="leemarme humuspodzolgronden",
+            string="Leemarme humuspodzolgronden",
             codes=[
                 "Hn21",
                 "Hn30",
@@ -227,12 +227,12 @@ class BodemType(Enum):
             enkel_negatieven=False,
         ),
         "LEMIGE_HUMUSPODZOLGRONDEN": BodemTuple(
-            string="lemige humuspodzolgronden",
+            string="Lemige humuspodzolgronden",
             codes=["Hn23", "cHn23", "Hd23", "cHd23"],
             enkel_negatieven=False,
         ),
         "VAAGGRONDEN": BodemTuple(
-            string="vaaggronden",
+            string="Vaaggronden",
             codes=[
                 # Kalkloze zandgronden -> Vaaggronden
                 "Zn21",
@@ -367,17 +367,17 @@ class BodemType(Enum):
             enkel_negatieven=False,
         ),
         "LEEMARME_VAAGGRONDEN_H9190": BodemTuple(
-            string="leemarme vaaggronden",
+            string="Leemarme vaaggronden",
             codes=["Zn21", "Zd21", "Zb21", "Zn30", "Zd30", "Zb30"],
             enkel_negatieven=True,
         ),
         "PODZOLGRONDEN_MET_EEN_ZANDDEK_H9190": BodemTuple(
-            string="podzolgronden met een zanddek",
+            string="Podzolgronden met een zanddek",
             codes=["zY21", "zhY21", "zY21g", "zY30", "zhY30", "zY30g"],
             enkel_negatieven=False,
         ),
         "MODERPODZOLGRONDEN": BodemTuple(
-            string="moderpodzolgronden",
+            string="Moderpodzolgronden",
             codes=[
                 "Y21",
                 "Y23",
@@ -391,12 +391,12 @@ class BodemType(Enum):
             enkel_negatieven=False,
         ),
         "OUDE_KLEIGRONDEN": BodemTuple(
-            string="oude kleigronden",
+            string="Oude kleigronden",
             codes=["KT", "KX"],
             enkel_negatieven=False,
         ),
         "LEEMGRONDEN": BodemTuple(
-            string="leemgronden",
+            string="Leemgronden",
             codes=[
                 "pLn5",
                 "pLn6",
@@ -441,42 +441,49 @@ class LBKType(Enum):
         - Is dit type sluitend of is het enkel voor negatieven?
     """
 
-    HOOGVEENLANDSCHAP = "hoogveenlandschap"
-    HOOGVEEN = "hoogveen"
-    HERSTELLEND_HOOGVEEN = "herstellend hoogveen"
-    ZANDVERSTUIVING = "zandverstuiving"
-    ONDER_INVLOED_VAN_BEEK_OF_RIVIER = "onder invloed van beek of rivier"
+    HOOGVEENLANDSCHAP = "Hoogveenlandschap"
+    HOOGVEEN = "Hoogveen"
+    HERSTELLEND_HOOGVEEN = "Herstellend hoogveen"
+    ZANDVERSTUIVING = "Zandverstuiving"
+    ONDER_INVLOED_VAN_BEEK_OF_RIVIER = "Onder invloed van beek of rivier"
+    DEMO_ZOWEL_POSITIEF_ALS_NEGATIEF = "demo_zowel_positief_als_negatief"
 
     _tuple_dict = {
         "HOOGVEENLANDSCHAP": LBKTuple(
-            string="hoogveenlandschap",
+            string="Hoogveenlandschap",
             codes=["HzHL", "HzHD", "HzHO", "HzHK"],
             enkel_negatieven=False,
             enkel_positieven=True,
         ),
         "HOOGVEEN": LBKTuple(
-            string="hoogveen",
+            string="Hoogveen",
             codes=["HzHL", "HzHD", "HzHO", "HzHK"],
             enkel_negatieven=True,
             enkel_positieven=False,
         ),
         "HERSTELLEND_HOOGVEEN": LBKTuple(
-            string="herstellend hoogveen",
+            string="Herstellend hoogveen",
             codes=["HzHL", "HzHD", "HzHO", "HzHK"],
             enkel_negatieven=True,
             enkel_positieven=False,
         ),
         "ZANDVERSTUIVING": LBKTuple(
-            string="zandverstuiving",
+            string="Zandverstuiving",
             codes=["HzSD", "HzSDa", "HzSF", "HzSFa", "HzSL", "HzSLa", "HzSX", "HzSXa"],
             enkel_negatieven=True,
             enkel_positieven=False,
         ),
         "ONDER_INVLOED_VAN_BEEK_OF_RIVIER": LBKTuple(
-            string="onder invloed van beek of rivier",
+            string="Onder invloed van beek of rivier",
             codes=["HzBB", "HzBN", "HzBV", "HzBW", "HzBL", "HzBD", "HlDB", "HlDD"],
             enkel_negatieven=False,
             enkel_positieven=True,
+        ),
+        "DEMO_ZOWEL_POSITIEF_ALS_NEGATIEF": LBKTuple(
+            string="demo_zowel_positief_als_negatief",
+            codes=["demo"],
+            enkel_negatieven=False,
+            enkel_positieven=False,
         ),
     }
 
@@ -490,3 +497,7 @@ class LBKType(Enum):
     @property
     def enkel_negatieven(self):
         return LBKType._tuple_dict.value[self.name].enkel_negatieven
+
+    @property
+    def enkel_positieven(self):
+        return LBKType._tuple_dict.value[self.name].enkel_positieven

--- a/veg2hab/enums.py
+++ b/veg2hab/enums.py
@@ -19,7 +19,9 @@ class LBKTypeInfo:
 
     def __post_init__(self):
         if self.enkel_negatieven and self.enkel_positieven:
-            raise ValueError("Een LBKTypeInfo kan niet enkel negatieven en enkel positieven zijn")
+            raise ValueError(
+                "Een LBKTypeInfo kan niet enkel negatieven en enkel positieven zijn"
+            )
 
 
 class FuncSamenhangID(NamedTuple):

--- a/veg2hab/enums.py
+++ b/veg2hab/enums.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from dataclasses import dataclass
 from enum import Enum, IntEnum, auto
 from typing import List, NamedTuple, Tuple
 
@@ -9,11 +10,16 @@ class BodemTuple(NamedTuple):
     enkel_negatieven: bool
 
 
-class LBKTuple(NamedTuple):
+@dataclass
+class LBKTypeInfo:
     string: str
     codes: List[str]
     enkel_negatieven: bool
     enkel_positieven: bool
+
+    def __post_init__(self):
+        if self.enkel_negatieven and self.enkel_positieven:
+            raise ValueError("Een LBKTypeInfo kan niet enkel negatieven en enkel positieven zijn")
 
 
 class FuncSamenhangID(NamedTuple):
@@ -448,31 +454,31 @@ class LBKType(Enum):
     ONDER_INVLOED_VAN_BEEK_OF_RIVIER = "Onder invloed van beek of rivier"
 
     _tuple_dict = {
-        "HOOGVEENLANDSCHAP": LBKTuple(
+        "HOOGVEENLANDSCHAP": LBKTypeInfo(
             string="Hoogveenlandschap",
             codes=["HzHL", "HzHD", "HzHO", "HzHK"],
             enkel_negatieven=False,
             enkel_positieven=True,
         ),
-        "HOOGVEEN": LBKTuple(
+        "HOOGVEEN": LBKTypeInfo(
             string="Hoogveen",
             codes=["HzHL", "HzHD", "HzHO", "HzHK"],
             enkel_negatieven=True,
             enkel_positieven=False,
         ),
-        "HERSTELLEND_HOOGVEEN": LBKTuple(
+        "HERSTELLEND_HOOGVEEN": LBKTypeInfo(
             string="Herstellend hoogveen",
             codes=["HzHL", "HzHD", "HzHO", "HzHK"],
             enkel_negatieven=True,
             enkel_positieven=False,
         ),
-        "ZANDVERSTUIVING": LBKTuple(
+        "ZANDVERSTUIVING": LBKTypeInfo(
             string="Zandverstuiving",
             codes=["HzSD", "HzSDa", "HzSF", "HzSFa", "HzSL", "HzSLa", "HzSX", "HzSXa"],
             enkel_negatieven=True,
             enkel_positieven=False,
         ),
-        "ONDER_INVLOED_VAN_BEEK_OF_RIVIER": LBKTuple(
+        "ONDER_INVLOED_VAN_BEEK_OF_RIVIER": LBKTypeInfo(
             string="Onder invloed van beek of rivier",
             codes=["HzBB", "HzBN", "HzBV", "HzBW", "HzBL", "HzBD", "HlDB", "HlDD"],
             enkel_negatieven=False,

--- a/veg2hab/enums.py
+++ b/veg2hab/enums.py
@@ -446,7 +446,6 @@ class LBKType(Enum):
     HERSTELLEND_HOOGVEEN = "Herstellend hoogveen"
     ZANDVERSTUIVING = "Zandverstuiving"
     ONDER_INVLOED_VAN_BEEK_OF_RIVIER = "Onder invloed van beek of rivier"
-    DEMO_ZOWEL_POSITIEF_ALS_NEGATIEF = "demo_zowel_positief_als_negatief"
 
     _tuple_dict = {
         "HOOGVEENLANDSCHAP": LBKTuple(
@@ -478,12 +477,6 @@ class LBKType(Enum):
             codes=["HzBB", "HzBN", "HzBV", "HzBW", "HzBL", "HzBD", "HlDB", "HlDD"],
             enkel_negatieven=False,
             enkel_positieven=True,
-        ),
-        "DEMO_ZOWEL_POSITIEF_ALS_NEGATIEF": LBKTuple(
-            string="demo_zowel_positief_als_negatief",
-            codes=["demo"],
-            enkel_negatieven=False,
-            enkel_positieven=False,
         ),
     }
 

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from numbers import Number
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Set, Tuple, Union
 
 import geopandas as gpd
 import pandas as pd
@@ -269,6 +269,22 @@ def mozaiekregel_habtype_percentage_dict_to_string(
     )
 
 
+def format_opmerkingen(
+    voorstellen: Union[HabitatVoorstel, List[HabitatVoorstel]]
+) -> str:
+    """
+    Uit ieder habitatvoorstel.mits.get_opm() komt een Set(str)
+    Bij meerdere voorstellen zijn er meerdere mitsen, dus List[Set[str]]
+    Deze moeten onderling nog uniek gemaakt worden en daarna gejoined worden tot één string
+    """
+    if not isinstance(voorstellen, list):
+        voorstellen = [voorstellen]
+
+    opmerkingen = [voorstel.mits.get_opm() for voorstel in voorstellen]
+
+    return "\n".join(set.union(*opmerkingen))
+
+
 def hab_as_final_format(print_info: tuple, idx: int, opp: float) -> pd.Series:
     """
     Herformatteert een habitatkeuze en bijbehorende vegtypeinfo naar de kolommen zoals in het Gegevens Leverings Protocol
@@ -294,7 +310,9 @@ def hab_as_final_format(print_info: tuple, idx: int, opp: float) -> pd.Series:
                 f"Perc{idx}": vegtypeinfo.percentage,
                 f"Opp{idx}": opp * (vegtypeinfo.percentage / 100),
                 f"Kwal{idx}": keuze.kwaliteit.as_letter(),
-                f"Opm{idx}": keuze.opmerking,
+                f"Opm{idx}": keuze.opmerking
+                + (" " if len(keuze.opmerking) > 0 else "")
+                + format_opmerkingen(voorstel),
                 f"_Mits_opm{idx}": keuze.mits_opmerking,
                 f"_Mozk_opm{idx}": keuze.mozaiek_opmerking,
                 f"_MozkPerc{idx}": mozaiekregel_habtype_percentage_dict_to_string(
@@ -351,7 +369,9 @@ def hab_as_final_format(print_info: tuple, idx: int, opp: float) -> pd.Series:
             f"Perc{idx}": str(vegtypeinfo.percentage),
             f"Opp{idx}": str(opp * (vegtypeinfo.percentage / 100)),
             f"Kwal{idx}": keuze.kwaliteit.as_letter(),
-            f"Opm{idx}": keuze.opmerking,
+            f"Opm{idx}": keuze.opmerking
+            + (" " if len(keuze.opmerking) > 0 else "")
+            + format_opmerkingen(voorstellen),
             f"_Mits_opm{idx}": keuze.mits_opmerking,
             f"_Mozk_opm{idx}": keuze.mozaiek_opmerking,
             f"_MozkPerc{idx}": mozaiekregel_habtype_percentage_dict_to_string(

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -311,7 +311,7 @@ def hab_as_final_format(print_info: tuple, idx: int, opp: float) -> pd.Series:
                 f"Opp{idx}": opp * (vegtypeinfo.percentage / 100),
                 f"Kwal{idx}": keuze.kwaliteit.as_letter(),
                 f"Opm{idx}": keuze.opmerking
-                + (" " if len(keuze.opmerking) > 0 else "")
+                + ("\n" if len(keuze.opmerking) > 0 else "")
                 + format_opmerkingen(voorstel),
                 f"_Mits_opm{idx}": keuze.mits_opmerking,
                 f"_Mozk_opm{idx}": keuze.mozaiek_opmerking,
@@ -370,7 +370,7 @@ def hab_as_final_format(print_info: tuple, idx: int, opp: float) -> pd.Series:
             f"Opp{idx}": str(opp * (vegtypeinfo.percentage / 100)),
             f"Kwal{idx}": keuze.kwaliteit.as_letter(),
             f"Opm{idx}": keuze.opmerking
-            + (" " if len(keuze.opmerking) > 0 else "")
+            + ("\n" if len(keuze.opmerking) > 0 else "")
             + format_opmerkingen(voorstellen),
             f"_Mits_opm{idx}": keuze.mits_opmerking,
             f"_Mozk_opm{idx}": keuze.mozaiek_opmerking,


### PR DESCRIPTION
Van boven naar beneden in de changed files:
- mitsjson.json: Ik heb hoofdletters aan het begin van alle bodem en lbk typen gedaan, zodat deze matchen met de fgr en zodat ze in een zin in de output wat meer opvallen als een term met betekenis.
- demo_criteria_opmerkingen.ipynb: Overzicht van alle smaken mits met alles smaken opmerking. Aangezien een test hiervoor niet heel nuttig lijkt, maar ik toch een overzicht wilde hebben ter controle, heb ik er maar een notebookje voor gemaakt. 
- test_criteria.py: Basic tests voor elke criteria; hadden er al eerder moeten zijn (want dan was opgevallen dat de bodem en lbk typen helemaal niet goed gecheckt werden.
- criteria.py:
  - Alle criteria hebben nu een get_opm() die een set met daarin een zin teruggeeft. Het is een set zodat we en in en/of criteria en aan het eind voor de output makkelijk kunnen Unionen om dubbelingen weg te halen. En/OfCriteria geven de set met alle zinnen in de sub criteria terug. 
   - FGR, bodem en LBK hebben een wanted en een actual type/code, zodat het gewilde en het tegengekomen type los bewaard kan worden. Deze worden bij bodem en LBK nu daadwerkelijk goed gecheckt, en ook de enkel_negatieven/positieven worden goed meegenomen.
  - De dynamische opmerkingzinnen van bodem en LBK zijn best complex, maar hier kom ik niet echt handig omheen anders ben ik bang. De demo_criteria_opmerkingen notebook laat de mogelijkheden goed zien.
- enums.py: Alle bodem en lbk typen hebben nu een hoofdletter, en LBKType heeft nu ook een property voor enkel_positieven.
- vegkartering.py: Een method format_opmerkingen waar hab_as_final_format een (collectie aan) habitatvoorstellen in kan gooien en dan krijgt het heel handig alle opmerkingen terug.