### PR TITLE
SPH-791 Info uit bronkaarten obv grootste overlap ipv compleet binnen een vlak 

### DIFF
--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -5,6 +5,7 @@ from veg2hab.criteria import (
     BodemCriterium,
     EnCriteria,
     FGRCriterium,
+    GeenCriterium,
     LBKCriterium,
     NietCriterium,
     NietGeautomatiseerdCriterium,
@@ -13,6 +14,12 @@ from veg2hab.criteria import (
 from veg2hab.enums import BodemType, FGRType, LBKType, MaybeBoolean
 
 # For "tests" of criteria.get_opm, please see demo_criteria_opmerkingen.py
+
+
+def test_GeenCriterium():
+    crit = GeenCriterium()
+    crit.check(pd.Series())
+    assert crit.evaluation == MaybeBoolean.TRUE
 
 
 def test_FGRCriterium():

--- a/veg2hab/bronnen.py
+++ b/veg2hab/bronnen.py
@@ -62,6 +62,10 @@ def sjoin_largest_overlap(
     assert (
         bron_col_name in bron_gdf.columns
     ), f"Kolom {bron_col_name} moet in bron_gdf zitten"
+    # assert index is unique
+    assert len(kartering_gdf.index) == len(
+        kartering_gdf.index.unique()
+    ), "Index moet uniek zijn"
     if bron_col_name in kartering_gdf.columns:
         kartering_gdf = kartering_gdf.drop(columns=[bron_col_name])
 

--- a/veg2hab/bronnen.py
+++ b/veg2hab/bronnen.py
@@ -96,9 +96,6 @@ def sjoin_largest_overlap(
         kartering_gdf
     ), "DF met bronvlakcodes moet even lang zijn als de kartering_gdf"
 
-    # if len(only_largest_overlaps) == 0:
-    #     return pd.Series(index=kartering_gdf.index, name=bron_col_name)
-
     return only_largest_overlaps[bron_col_name]
 
 

--- a/veg2hab/bronnen.py
+++ b/veg2hab/bronnen.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 import geopandas as gpd
+import pandas as pd
 from typing_extensions import Self
 
 import veg2hab.constants
@@ -52,6 +53,55 @@ def get_datadir(app_author: str, app_name: str) -> Path:
     return p / app_author / app_name
 
 
+def sjoin_largest_overlap(
+    kartering_gdf: gpd.GeoDataFrame, bron_gdf: gpd.GeoDataFrame, bron_col_name: str
+) -> gpd.GeoSeries:
+    """
+    Voegt de kolommen van bron_gdf toe aan kartering_gdf op basis van de grootste overlap.
+    """
+    assert (
+        bron_col_name in bron_gdf.columns
+    ), f"Kolom {bron_col_name} moet in bron_gdf zitten"
+    if bron_col_name in kartering_gdf.columns:
+        kartering_gdf = kartering_gdf.drop(columns=[bron_col_name])
+
+    # Extra kolom met de geometry zodat deze blijft bestaan na de sjoin
+    bron_gdf["geometry_bron"] = bron_gdf["geometry"]
+
+    joined = gpd.sjoin(kartering_gdf, bron_gdf, how="left", predicate="intersects")
+    joined["overlap_area"] = joined.geometry.intersection(joined.geometry_bron).area
+
+    def _retain_largest_overlap_area_row(group):
+        assert len(group) > 0, "Group mag niet leeg zijn"
+
+        # Als er maar 1 is hoeven we niks te doen
+        if len(group) == 1:
+            return group
+
+        highest_overlap_area = group["overlap_area"].max()
+        # Enkel de eerste teruggeven voor het geval er meerdere met dezelfde area zijn
+        if len(group[group["overlap_area"] == highest_overlap_area]) > 1:
+            logging.warning(
+                f"Meerdere bronvlakken met dezelfde overlap area gevonden; alleen de eerste wordt gebruikt"
+            )
+        return group[group["overlap_area"] == highest_overlap_area].iloc[[0]]
+
+    # Groupby index, zodat we groepen maken per karteringvlak
+    grouped = joined.groupby(level=0, group_keys=False)
+    only_largest_overlaps = grouped.apply(_retain_largest_overlap_area_row)
+
+    bron_gdf = bron_gdf.drop(columns=["geometry_bron"])
+
+    assert len(only_largest_overlaps) == len(
+        kartering_gdf
+    ), "DF met bronvlakcodes moet even lang zijn als de kartering_gdf"
+
+    # if len(only_largest_overlaps) == 0:
+    #     return pd.Series(index=kartering_gdf.index, name=bron_col_name)
+
+    return only_largest_overlaps[bron_col_name]
+
+
 class LBK:
     def __init__(self, gdf: gpd.GeoDataFrame):
         if set(gdf.columns) != {"geometry", "lbk"}:
@@ -78,9 +128,9 @@ class LBK:
             or get_checksum(local_path) != veg2hab.constants.LBK_CHECKSUM
         ):
             logging.warning(
-                "Lokale versie LBK kaart komt niet overeen of bestaat nog niet. Downloaden van github kan enkele minuten duren. Even geduld aub."
+                "Lokale versie LBK komt niet overeen of bestaat nog niet. Downloaden van github kan enkele minuten duren. Even geduld aub."
             )
-            logging.debug(f"Download bodemkaart van {remote_path} naar {local_path}")
+            logging.debug(f"Download LBK van {remote_path} naar {local_path}")
             local_path.parent.mkdir(parents=True, exist_ok=True)
             urllib.request.urlretrieve(remote_path, local_path)
 
@@ -88,10 +138,10 @@ class LBK:
 
     def for_geometry(self, other_gdf: gpd.GeoDataFrame) -> gpd.GeoSeries:
         """
-        Returns bodemkaart codes voor de gegeven geometrie
+        Returns LBK codes voor de gegeven geometrie
         """
         assert "geometry" in other_gdf.columns
-        return gpd.sjoin(other_gdf, self.gdf, how="left", predicate="within").lbk
+        return sjoin_largest_overlap(other_gdf, self.gdf, "lbk")
 
 
 class FGR:
@@ -108,7 +158,7 @@ class FGR:
         Returns fgr codes voor de gegeven geometrie
         """
         assert "geometry" in other_gdf.columns
-        return gpd.sjoin(other_gdf, self.gdf, how="left", predicate="within").fgr
+        return sjoin_largest_overlap(other_gdf, self.gdf, "fgr")
 
 
 class Bodemkaart:
@@ -130,6 +180,12 @@ class Bodemkaart:
             layer="soilarea_soilunit",
             include_fields=["maparea_id", "soilunit_code"],
             ignore_geometry=True,
+        )
+        # Samenvoegen meerdere bodemtypen voor 1 vlak/maparea_id
+        soil_units_table = (
+            soil_units_table.groupby("maparea_id")["soilunit_code"]
+            .apply(list)
+            .reset_index()
         )
         gdf = soil_area.merge(soil_units_table, on="maparea_id")[
             ["geometry", "soilunit_code"]
@@ -160,11 +216,4 @@ class Bodemkaart:
         Returns bodemkaart codes voor de gegeven geometrie
         """
         assert "geometry" in other_gdf.columns
-        bodemtypen_per_index = gpd.sjoin(
-            other_gdf, self.gdf, how="left", predicate="within"
-        ).bodem
-        # Vlakken kunnen meer dan 1 bodemtype krijgen, die gevallen moeten gecombineerd worden
-        bodemtypen_per_index = bodemtypen_per_index.groupby(
-            bodemtypen_per_index.index
-        ).apply(lambda bodemtypen: [bodemtype for bodemtype in bodemtypen])
-        return bodemtypen_per_index
+        return sjoin_largest_overlap(other_gdf, self.gdf, "bodem")

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -161,20 +161,24 @@ class BodemCriterium(BeperkendCriterium):
 
     def check(self, row: gpd.GeoSeries) -> None:
         assert "bodem" in row, "bodem kolom niet aanwezig"
-        self.actual_bodemcode = row["bodem"]
-        if not isinstance(row["bodem"], List) and pd.isna(row["bodem"]):
+        self.actual_bodemcode = (
+            None
+            if not isinstance(row["bodem"], list) and pd.isna(row["bodem"])
+            else row["bodem"]
+        )
+        if self.actual_bodemcode is None:
             # Er is een NaN als het vlak niet binnen een bodemkaartvlak valt
             self.cached_evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
             return
-        assert isinstance(row["bodem"], list), "bodem kolom moet een list zijn"
+        assert isinstance(self.actual_bodemcode, list), "bodem kolom moet een list zijn"
 
-        if len(row["bodem"]) > 1:
+        if len(self.actual_bodemcode) > 1:
             # Vlak heeft meerdere bodemtypen, kunnen we niet automatiseren
             self.cached_evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
             return
 
         self.cached_evaluation = MaybeBoolean.FALSE
-        for code in row["bodem"]:
+        for code in self.actual_bodemcode:
             if code in self.wanted_bodemtype.codes:
                 self.cached_evaluation = MaybeBoolean.TRUE
                 break

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -197,10 +197,9 @@ class BodemCriterium(BeperkendCriterium):
                 "Er wordt om opmerking-strings gevraagd voordat de mits is gecheckt."
             )
 
-        if len(self.actual_bodemcode) == 1:
-            if pd.isna(self.actual_bodemcode[0]):
-                return {"Dit vlak ligt niet mooi binnen één bodemkaartvlak."}
-
+        if not isinstance(self.actual_bodemcode, list) and pd.isna(self.actual_bodemcode):
+            return {"Dit vlak ligt niet binnen een bodemkaartvlak."}
+        
         framework = (
             "Dit is {}{}"
             + str(self.wanted_bodemtype)

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -197,9 +197,11 @@ class BodemCriterium(BeperkendCriterium):
                 "Er wordt om opmerking-strings gevraagd voordat de mits is gecheckt."
             )
 
-        if not isinstance(self.actual_bodemcode, list) and pd.isna(self.actual_bodemcode):
+        if not isinstance(self.actual_bodemcode, list) and pd.isna(
+            self.actual_bodemcode
+        ):
             return {"Dit vlak ligt niet binnen een bodemkaartvlak."}
-        
+
         framework = (
             "Dit is {}{}"
             + str(self.wanted_bodemtype)

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -161,17 +161,15 @@ class BodemCriterium(BeperkendCriterium):
 
     def check(self, row: gpd.GeoSeries) -> None:
         assert "bodem" in row, "bodem kolom niet aanwezig"
-        assert isinstance(row["bodem"], list), "bodem kolom moet een list zijn"
-
         self.actual_bodemcode = row["bodem"]
+        if not isinstance(row["bodem"], List) and pd.isna(row["bodem"]):
+            # Er is een NaN als het vlak niet binnen een bodemkaartvlak valt
+            self.cached_evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
+            return
+        assert isinstance(row["bodem"], list), "bodem kolom moet een list zijn"
 
         if len(row["bodem"]) > 1:
             # Vlak heeft meerdere bodemtypen, kunnen we niet automatiseren
-            self.cached_evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
-            return
-
-        if pd.isna(row["bodem"]):
-            # Er is een NaN als het vlak niet binnen een bodemkaartvlak valt
             self.cached_evaluation = MaybeBoolean.CANNOT_BE_AUTOMATED
             return
 

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -1153,8 +1153,10 @@ class Kartering:
         if lbk_needed.any():
             mits_info_df["lbk"] = lbk.for_geometry(mits_info_df.loc[lbk_needed])
         if bodem_needed.any():
-            mits_info_df["bodem"] = bodemkaart.for_geometry(mits_info_df.loc[bodem_needed])
-        
+            mits_info_df["bodem"] = bodemkaart.for_geometry(
+                mits_info_df.loc[bodem_needed]
+            )
+
         ### Mitsen checken
         for idx, row in self.gdf.iterrows():
             mits_info_row = mits_info_df.loc[idx]

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -1148,16 +1148,13 @@ class Kartering:
         )
 
         ### Verrijken met de benodigde informatie
-        mits_info_df["fgr"] = fgr.for_geometry(mits_info_df.loc[fgr_needed]).drop(
-            columns="index_right"
-        )
-        mits_info_df["bodem"] = bodemkaart.for_geometry(
-            mits_info_df.loc[bodem_needed]
-        ).drop(columns="index_right")
-        mits_info_df["lbk"] = lbk.for_geometry(mits_info_df.loc[lbk_needed]).drop(
-            columns="index_right"
-        )
-
+        if fgr_needed.any():
+            mits_info_df["fgr"] = fgr.for_geometry(mits_info_df.loc[fgr_needed])
+        if lbk_needed.any():
+            mits_info_df["lbk"] = lbk.for_geometry(mits_info_df.loc[lbk_needed])
+        if bodem_needed.any():
+            mits_info_df["bodem"] = bodemkaart.for_geometry(mits_info_df.loc[bodem_needed])
+        
         ### Mitsen checken
         for idx, row in self.gdf.iterrows():
             mits_info_row = mits_info_df.loc[idx]


### PR DESCRIPTION
Alle `bron.for_geometry` werken nu via de nieuwe `sjoin_largest_overlap` functie. 

Bodemkaart voegt nu in from_file al vlakken met meerdere bodemtypen samen tot 1 lijst.

Beetje gegoochel aan het begin van BodemCriterium.check zodat hij goed om kan gaan met zowel `[*bodemtype*]` (normaal geval), `[*bodemtype1*, *bodemtype2*]` (zeldzamer, maar pd.isnan geeft hier [bool, bool] terug wat geen valid truth value heeft), en met `nan` (ligt niet binnen een bodemvlak).
 