### PR TITLE
Fix issue in serialization / deserialization of MozkPercTuple

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "veg2hab"
-version = "0.3.1a0"
+version = "0.3.1a1"
 description = "Package voor automatisch omzetten van vegetatiekarteringen naar habitatkaarten"
 authors = ["Spheer.ai <info@spheer.ai>"]
 readme = "README.md"

--- a/veg2hab/__init__.py
+++ b/veg2hab/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.3.1a0"
+__version__ = "0.3.1a1"
 
 from .main import installatie_instructies, run

--- a/veg2hab/mozaiek.py
+++ b/veg2hab/mozaiek.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict, namedtuple
 from numbers import Number
-from typing import ClassVar, Dict, List, Optional, Set, Tuple, Union
+from typing import ClassVar, Dict, List, Optional, Set, Tuple, Union, NamedTuple
 
 import geopandas as gpd
 import pandas as pd
@@ -11,8 +11,10 @@ from veg2hab.enums import Kwaliteit, MaybeBoolean, NumberType
 from veg2hab.io.common import Interface
 from veg2hab.vegetatietypen import SBB, VvN
 
-MozkPercTuple = namedtuple("MozkPercTuple", ["habtype", "kwaliteit", "percentage"])
-
+class MozkPercTuple(NamedTuple):
+    habtype: str
+    kwaliteit: Kwaliteit
+    percentage: NumberType
 
 class MozaiekRegel(BaseModel):
     # NOTE: Mogelijk kunnen we in de toekomst van deze structuur af en met maar 1 type mozaiekregel werken

--- a/veg2hab/mozaiek.py
+++ b/veg2hab/mozaiek.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict, namedtuple
 from numbers import Number
-from typing import ClassVar, Dict, List, Optional, Set, Tuple, Union, NamedTuple
+from typing import ClassVar, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 import geopandas as gpd
 import pandas as pd

--- a/veg2hab/mozaiek.py
+++ b/veg2hab/mozaiek.py
@@ -11,10 +11,12 @@ from veg2hab.enums import Kwaliteit, MaybeBoolean, NumberType
 from veg2hab.io.common import Interface
 from veg2hab.vegetatietypen import SBB, VvN
 
+
 class MozkPercTuple(NamedTuple):
     habtype: str
     kwaliteit: Kwaliteit
     percentage: NumberType
+
 
 class MozaiekRegel(BaseModel):
     # NOTE: Mogelijk kunnen we in de toekomst van deze structuur af en met maar 1 type mozaiekregel werken

--- a/veg2hab/package_data/veg2hab.pyt
+++ b/veg2hab/package_data/veg2hab.pyt
@@ -6,7 +6,7 @@ import veg2hab.constants
 import veg2hab.io.arcgis
 import veg2hab.main
 
-SUPPORTED_VERSIONS = ["0.3.0a1", "0.3.0a2", "0.3.0a3", "0.3.1a0"]
+SUPPORTED_VERSIONS = ["0.3.0a1", "0.3.0a2", "0.3.0a3", "0.3.1a0", "0.3.1a1"]
 
 # this instantiates the arcgis interface and configures the logging
 veg2hab.io.arcgis.ArcGISInterface.get_instance().instantiate_loggers()


### PR DESCRIPTION
De enum werd weggeschreven als string en vervolgens niet meer terug omgezet naar de enum waarde.

@JRdeLange, ik denk dat het goed is om de tool_by_tool walkthrough.ipynb als onderdeel van onze tests maken. Dit had deze fout namelijk prima afgevangen!