### PR TITLE
SPH-529 - Oude Bossenkaart mitsen v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Veg2hab is afhankelijk van verschillende bronbestanden tijdens het omzetten van 
  - [Fysisch-Geografische Regio kaart (afgekort tot FGR)](./data/bronbestanden/FGR.json) (versie 2013, [link naar origineel op Nationaal georegister](https://nationaalgeoregister.nl/geonetwork/srv/dut/catalog.search#/metadata/c8b5668f-c354-42f3-aafc-d15ae54cf170)).
  - [Landschappelijke Bodem Kaart (afgekort tot LBK)](https://bodemdata.nl/downloads) (versie 2023): dit bestand wordt gebruikt voor het controleren van beperkende criteria met betrekking tot sommige bodemtypen en hoogveen.
  - [Bodemkaart van Nederland](https://www.atlasleefomgeving.nl/bodemkaart-van-nl-150000) (versie 2021): dit bestand wordt gebruikt voor het controleren van beperkende criteria met betrekking tot bodemtypen.
+ - [Oude Bossenkaart](./data/bronbestanden/Oudebossen.gpkg): dit bestand wordt gebruikt voor het controleren van beperkende criteria met betrekking tot bosgroeiplaatsen ouder dan 1850.
 
 **Let op**: bij volgende versies van veg2hab komen er mogelijk meer bronbestanden bij.
 

--- a/data/bronbestanden/Oudebossen.gpkg
+++ b/data/bronbestanden/Oudebossen.gpkg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:529e3b6c09ebfdd63806ac6d08b599cbdcfebc2b2424766e6e11470f3f396bbb
+size 3059712

--- a/data/mitsjson.json
+++ b/data/mitsjson.json
@@ -1177,8 +1177,16 @@
                 ]
             },
             {
-                "type": "NietGeautomatiseerd",
-                "toelichting": "mits onderdeel van een minimaal honderdjarige opstand van zomereik of op een bosgroeiplaats ouder dan 1850"
+                "type": "OfCriteria",
+                "sub_criteria": [
+                    {
+                        "type": "NietGeautomatiseerd",
+                        "toelichting": "onderdeel van een minimaal honderdjarige opstand van zomereik"
+                    },
+                    {
+                        "type": "OudeBossenCriterium"
+                    }
+                ]
             },
             {
                 "type": "NietCriterium",
@@ -1214,8 +1222,16 @@
                 ]
             },
             {
-                "type": "NietGeautomatiseerd",
-                "toelichting": "mits op een bosgroeiplaats ouder dan 1850 of in een daaraan grenzende minimaal honderdjarige bosopstand"
+                "type": "OfCriteria",
+                "sub_criteria": [
+                    {
+                        "type": "OudeBossenCriterium"
+                    },
+                    {
+                        "type": "NietGeautomatiseerd",
+                        "toelichting": "100 jarige bosopstand grenzend aan een bosgroeiplaats ouder dan 1850"
+                    }
+                ]
             },
             {
                 "type": "NietCriterium",
@@ -1299,7 +1315,19 @@
             },
             {
                 "type": "NietGeautomatiseerd",
-                "toelichting": "mits zonder hydromorfe kenmerken en mits op een bosgroeiplaats ouder dan 1850 of in een daaraan grenzende minimaal honderdjarige bosopstand"
+                "toelichting": "mits zonder hydromorfe kenmerken"
+            },
+            {
+                "type": "OfCriteria",
+                "sub_criteria": [
+                    {
+                        "type": "OudeBossenCriterium"
+                    },
+                    {
+                        "type": "NietGeautomatiseerd",
+                        "toelichting": "100 jarige bosopstand grenzend aan een bosgroeiplaats ouder dan 1850"
+                    }
+                ]
             },
             {
                 "type": "NietCriterium",

--- a/data/mitsjson.json
+++ b/data/mitsjson.json
@@ -1184,7 +1184,8 @@
                         "toelichting": "onderdeel van een minimaal honderdjarige opstand van zomereik"
                     },
                     {
-                        "type": "OudeBossenCriterium"
+                        "type": "OudeBossenCriterium",
+                        "for_habtype": "H9190"
                     }
                 ]
             },
@@ -1225,7 +1226,8 @@
                 "type": "OfCriteria",
                 "sub_criteria": [
                     {
-                        "type": "OudeBossenCriterium"
+                        "type": "OudeBossenCriterium",
+                        "for_habtype": "H9120"
                     },
                     {
                         "type": "NietGeautomatiseerd",
@@ -1321,7 +1323,8 @@
                 "type": "OfCriteria",
                 "sub_criteria": [
                     {
-                        "type": "OudeBossenCriterium"
+                        "type": "OudeBossenCriterium",
+                        "for_habtype": "H9120"
                     },
                     {
                         "type": "NietGeautomatiseerd",

--- a/notebooks/demo_criteria_opmerkingen.ipynb
+++ b/notebooks/demo_criteria_opmerkingen.ipynb
@@ -15,8 +15,8 @@
     }
    ],
    "source": [
-    "from veg2hab.criteria import FGRCriterium, LBKCriterium, BodemCriterium, EnCriteria, NietCriterium, OfCriteria\n",
-    "from veg2hab.enums import FGRType, LBKType, BodemType, LBKTuple\n",
+    "from veg2hab.criteria import FGRCriterium, LBKCriterium, BodemCriterium, EnCriteria, NietCriterium, OfCriteria, OudeBossenCriterium\n",
+    "from veg2hab.enums import FGRType, LBKType, BodemType, OBKWaarden\n",
     "import pandas as pd\n",
     "from enum import Enum"
    ]
@@ -88,9 +88,9 @@
       "FALSE\n",
       "{'Dit is niet Leemarme vaaggronden want bodemcode Abcd.'}\n",
       "--------\n",
-      "[<NA>]\n",
+      "<NA>\n",
       "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak.'}\n",
+      "{'Dit vlak ligt niet binnen een bodemkaartvlak.'}\n",
       "--------\n"
      ]
     }
@@ -98,7 +98,7 @@
    "source": [
     "lv = BodemCriterium(wanted_bodemtype=BodemType.LEEMARME_VAAGGRONDEN_H9190)\n",
     "\n",
-    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], [pd.NA]]:\n",
+    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], pd.NA]:\n",
     "    row = pd.Series({\"bodem\": bodem_code})\n",
     "    lv.check(row)\n",
     "    print(bodem_code)\n",
@@ -131,9 +131,9 @@
       "FALSE\n",
       "{'Dit is niet Vaaggronden want bodemcode Abcd.'}\n",
       "--------\n",
-      "[<NA>]\n",
+      "<NA>\n",
       "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak.'}\n",
+      "{'Dit vlak ligt niet binnen een bodemkaartvlak.'}\n",
       "--------\n"
      ]
     }
@@ -141,7 +141,7 @@
    "source": [
     "vg = BodemCriterium(wanted_bodemtype=BodemType.VAAGGRONDEN)\n",
     "\n",
-    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], [pd.NA]]:\n",
+    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], pd.NA]:\n",
     "    row = pd.Series({\"bodem\": bodem_code})\n",
     "    vg.check(row)\n",
     "    print(bodem_code)\n",
@@ -240,7 +240,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Combineren"
+    "Oude Bossenkaart"
    ]
   },
   {
@@ -252,24 +252,68 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "((LBK is Herstellend hoogveen (C) of LBK is Hoogveenlandschap (T) of Bodem is Leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (F))\n",
+      "<NA>\n",
+      "FALSE\n",
+      "{'Dit is geen oud bos, want niet binnen boskaartvlak.'}\n",
+      "--------\n",
+      "h9120=1 h9190=1\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit is mogelijk oud bos, want binnen boskaartvlak (H9120: 1, H9190: 1).'}\n",
+      "--------\n",
+      "h9120=0 h9190=2\n",
+      "CANNOT_BE_AUTOMATED\n",
+      "{'Dit is mogelijk oud bos, want binnen boskaartvlak (H9120: 0, H9190: 2).'}\n",
+      "--------\n"
+     ]
+    }
+   ],
+   "source": [
+    "obk = OudeBossenCriterium()\n",
+    "\n",
+    "for obk_waarde in [pd.NA, OBKWaarden(h9120=1, h9190=1), OBKWaarden(h9120=0, h9190=2)]:\n",
+    "    row = pd.Series({\"obk\": obk_waarde})\n",
+    "    obk.check(row)\n",
+    "    print(obk_waarde)\n",
+    "    print(obk.evaluation)\n",
+    "    print(obk.get_opm())\n",
+    "    print(\"--------\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Combineren\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "((LBK is Herstellend hoogveen (C) of LBK is Hoogveenlandschap (T) of Bodem is Leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (T))\n",
       "TRUE\n",
       "Dit is Hoogveenlandschap want LBK code HzHL.\n",
-      "FGR type is niet Laagveengebied, maar Duinen.\n",
       "Dit is niet Leemarme humuspodzolgronden want bodemcode Zn21.\n",
       "Dit is mogelijk Herstellend hoogveen want LBK code HzHL.\n",
+      "FGR type is niet Laagveengebied, maar Duinen.\n",
       "--------\n",
-      "((LBK is Herstellend hoogveen (F) of LBK is Hoogveenlandschap (C) of Bodem is Leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (T))\n",
+      "((LBK is Herstellend hoogveen (F) of LBK is Hoogveenlandschap (C) of Bodem is Leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (F))\n",
       "FALSE\n",
-      "Dit is niet Herstellend hoogveen want LBK code Abcd.\n",
       "Dit is mogelijk toch Hoogveenlandschap ondanks LBK code Abcd.\n",
-      "Dit is niet Leemarme humuspodzolgronden want bodemcode Abcd.\n",
       "FGR type is Laagveengebied.\n",
+      "Dit is niet Leemarme humuspodzolgronden want bodemcode Abcd.\n",
+      "Dit is niet Herstellend hoogveen want LBK code Abcd.\n",
       "--------\n",
       "((LBK is Herstellend hoogveen (C) of LBK is Hoogveenlandschap (C) of Bodem is Leemarme humuspodzolgronden (C)) en niet FGR is Laagveengebied (C))\n",
       "CANNOT_BE_AUTOMATED\n",
       "Dit vlak ligt niet mooi binnen één FGR-vlak.\n",
-      "Dit vlak ligt niet mooi binnen één bodemkaartvlak.\n",
+      "Dit vlak ligt niet binnen een bodemkaartvlak.\n",
       "Dit vlak ligt niet mooi binnen één LBK-vak\n",
       "--------\n"
      ]
@@ -292,7 +336,7 @@
     "    ]\n",
     ")\n",
     "\n",
-    "for lbk_code, fgr_code, bodem_code in [(\"HzHL\", FGRType.DU, [\"Zn21\"]), (\"Abcd\", FGRType.LV, [\"Abcd\"]), (pd.NA, pd.NA, [pd.NA])]:\n",
+    "for lbk_code, fgr_code, bodem_code in [(\"HzHL\", FGRType.DU, [\"Zn21\"]), (\"Abcd\", FGRType.LV, [\"Abcd\"]), (pd.NA, pd.NA, pd.NA)]:\n",
     "    row = pd.Series({\"lbk\": lbk_code, \"fgr\": fgr_code, \"bodem\": bodem_code})\n",
     "    crit.check(row)\n",
     "    print(str(crit))\n",

--- a/notebooks/functionality_test.ipynb
+++ b/notebooks/functionality_test.ipynb
@@ -26,8 +26,9 @@
                 "from veg2hab.definitietabel import DefinitieTabel, opschonen_definitietabel\n",
                 "from veg2hab.vegkartering import Kartering\n",
                 "from veg2hab.io.cli import CLIInterface\n",
+                "from veg2hab import constants\n",
                 "import pandas as pd\n",
-                "from veg2hab.bronnen import FGR, Bodemkaart, LBK\n",
+                "from veg2hab.bronnen import FGR, Bodemkaart, LBK, OudeBossenkaart\n",
                 "\n",
                 "pd.set_option('display.max_columns', 100)\n",
                 "\n",
@@ -143,9 +144,10 @@
             "outputs": [],
             "source": [
                 "mask = access_kartering.get_geometry_mask()\n",
-                "fgr = FGR(Path(\"../data/bronbestanden/FGR.json\"))\n",
+                "fgr = FGR(Path(constants.FGR_PATH))\n",
                 "bodemkaart = Bodemkaart.from_file(Path(\"../data/bronbestanden/bodemkaart.gpkg\"), mask=mask)\n",
-                "lbk = LBK.from_file(Path(\"../data/bronbestanden/lbk.shp\"), mask=mask)"
+                "lbk = LBK.from_file(Path(\"../data/bronbestanden/lbk.shp\"), mask=mask)\n",
+                "obk = OudeBossenkaart(Path(constants.OUDE_BOSSENKAART_PATH))"
             ]
         },
         {
@@ -208,8 +210,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "# access_kartering.bepaal_habitatkeuzes(fgr, bodemkaart, lbk)\n",
-                "access_kartering.bepaal_mits_habitatkeuzes(fgr, bodemkaart, lbk)\n",
+                "access_kartering.bepaal_mits_habitatkeuzes(fgr, bodemkaart, lbk, obk)\n",
                 "access_kartering.bepaal_mozaiek_habitatkeuzes()"
             ]
         },

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -86,20 +86,34 @@ def test_BodemCriterium_enkel_negatieven():
 
 
 def test_OudeBossenCriterium():
-    crit = OudeBossenCriterium()
+    crit = OudeBossenCriterium(for_habtype="H9120")
     row = pd.Series({"obk": pd.NA})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
-    row = pd.Series({"obk": OBKWaarden(h9120=0, h9190=0)})
+    row = pd.Series({"obk": OBKWaarden(H9120=0, H9190=0)})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
-    row = pd.Series({"obk": OBKWaarden(h9120=1, h9190=0)})
+
+    # for_habtype = H9120
+    row = pd.Series({"obk": OBKWaarden(H9120=1, H9190=0)})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
-    row = pd.Series({"obk": OBKWaarden(h9120=0, h9190=1)})
+    row = pd.Series({"obk": OBKWaarden(H9120=0, H9190=1)})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+    row = pd.Series({"obk": OBKWaarden(H9120=2, H9190=2)})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
-    row = pd.Series({"obk": OBKWaarden(h9120=2, h9190=2)})
+
+    # for_habtype = H9190
+    crit = OudeBossenCriterium(for_habtype="H9190")
+    row = pd.Series({"obk": OBKWaarden(H9120=1, H9190=0)})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+    row = pd.Series({"obk": OBKWaarden(H9120=0, H9190=1)})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+    row = pd.Series({"obk": OBKWaarden(H9120=2, H9190=2)})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
 

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -10,8 +10,9 @@ from veg2hab.criteria import (
     NietCriterium,
     NietGeautomatiseerdCriterium,
     OfCriteria,
+    OudeBossenCriterium,
 )
-from veg2hab.enums import BodemType, FGRType, LBKType, MaybeBoolean
+from veg2hab.enums import BodemType, FGRType, LBKType, MaybeBoolean, OBKWaarden
 
 # For "tests" of criteria.get_opm, please see demo_criteria_opmerkingen.py
 
@@ -82,6 +83,25 @@ def test_BodemCriterium_enkel_negatieven():
     row = pd.Series({"bodem": ["Abcd"]})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
+
+
+def test_OudeBossenCriterium():
+    crit = OudeBossenCriterium()
+    row = pd.Series({"obk": pd.NA})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+    row = pd.Series({"obk": OBKWaarden(h9120=0, h9190=0)})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.FALSE
+    row = pd.Series({"obk": OBKWaarden(h9120=1, h9190=0)})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+    row = pd.Series({"obk": OBKWaarden(h9120=0, h9190=1)})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
+    row = pd.Series({"obk": OBKWaarden(h9120=2, h9190=2)})
+    crit.check(row)
+    assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
 
 
 def test_EnCriteria():

--- a/tests/test_editable_vegtypen.py
+++ b/tests/test_editable_vegtypen.py
@@ -7,11 +7,11 @@ import pyodbc
 import pytest
 
 from veg2hab import constants
-from veg2hab.bronnen import FGR, LBK, Bodemkaart
+from veg2hab.bronnen import FGR, LBK, Bodemkaart, OudeBossenkaart
 from veg2hab.constants import WWL_PATH
 from veg2hab.definitietabel import DefinitieTabel
 from veg2hab.io.cli import CLIInterface
-from veg2hab.vegkartering import Kartering, VegTypeInfo, ingest_vegtype
+from veg2hab.vegkartering import Kartering
 from veg2hab.waswordtlijst import WasWordtLijst
 
 CLIInterface.get_instance()
@@ -57,10 +57,11 @@ def to_habtypekaart(kartering: Kartering) -> Kartering:
     lbk = LBK.from_file(
         path=Path(__file__).parent.joinpath("../data/bronbestanden/lbk.gpkg"), mask=mask
     )
+    obk = OudeBossenkaart(Path(constants.OUDE_BOSSENKAART_PATH))
 
     kartering.apply_deftabel(deftabel)
 
-    kartering.bepaal_mits_habitatkeuzes(fgr, bodemkaart, lbk)
+    kartering.bepaal_mits_habitatkeuzes(fgr, bodemkaart, lbk, obk)
     return kartering
 
 

--- a/veg2hab/bronnen.py
+++ b/veg2hab/bronnen.py
@@ -221,12 +221,13 @@ class Bodemkaart:
 
 
 class OudeBossenkaart:
-
     def __init__(self, path: Path, mask: Optional[gpd.GeoDataFrame] = None):
         self.gdf = gpd.read_file(path, mask=mask, include_fields=["h9120", "h9190"])
 
         # Validatie van de waarden gebeurt in het instantieren van OBKWaarden
-        self.gdf["obk"] = self.gdf.apply(lambda row: OBKWaarden(h9120=row.h9120, h9190=row.h9190), axis=1)
+        self.gdf["obk"] = self.gdf.apply(
+            lambda row: OBKWaarden(h9120=row.h9120, h9190=row.h9190), axis=1
+        )
         self.gdf = self.gdf.drop(columns=["h9120", "h9190"])
 
     def for_geometry(self, other_gdf: gpd.GeoDataFrame) -> gpd.GeoSeries:

--- a/veg2hab/bronnen.py
+++ b/veg2hab/bronnen.py
@@ -226,7 +226,7 @@ class OudeBossenkaart:
 
         # Validatie van de waarden gebeurt in het instantieren van OBKWaarden
         self.gdf["obk"] = self.gdf.apply(
-            lambda row: OBKWaarden(h9120=row.h9120, h9190=row.h9190), axis=1
+            lambda row: OBKWaarden(H9120=row.h9120, H9190=row.h9190), axis=1
         )
         self.gdf = self.gdf.drop(columns=["h9120", "h9190"])
 

--- a/veg2hab/constants.py
+++ b/veg2hab/constants.py
@@ -3,9 +3,7 @@ from pkg_resources import resource_filename
 # locaties van de meegepackagde bestanden
 TOOLBOX_PYT_PATH = resource_filename("veg2hab", "package_data/veg2hab.pyt")
 FGR_PATH = resource_filename("veg2hab", "package_data/FGR.json")
-OUDE_BOSSENKAART_PATH = resource_filename(
-    "veg2hab", "package_data/Oudebossen.gpkg"
-)
+OUDE_BOSSENKAART_PATH = resource_filename("veg2hab", "package_data/Oudebossen.gpkg")
 WWL_PATH = resource_filename("veg2hab", "package_data/opgeschoonde_waswordt.xlsx")
 DEFTABEL_PATH = resource_filename(
     "veg2hab", "package_data/opgeschoonde_definitietabel.xlsx"

--- a/veg2hab/constants.py
+++ b/veg2hab/constants.py
@@ -3,6 +3,9 @@ from pkg_resources import resource_filename
 # locaties van de meegepackagde bestanden
 TOOLBOX_PYT_PATH = resource_filename("veg2hab", "package_data/veg2hab.pyt")
 FGR_PATH = resource_filename("veg2hab", "package_data/FGR.json")
+OUDE_BOSSENKAART_PATH = resource_filename(
+    "veg2hab", "package_data/Oudebossen.gpkg"
+)
 WWL_PATH = resource_filename("veg2hab", "package_data/opgeschoonde_waswordt.xlsx")
 DEFTABEL_PATH = resource_filename(
     "veg2hab", "package_data/opgeschoonde_definitietabel.xlsx"

--- a/veg2hab/enums.py
+++ b/veg2hab/enums.py
@@ -12,8 +12,8 @@ class BodemTuple(NamedTuple):
 
 
 class OBKWaarden(BaseModel):
-    h9120: int = Field(ge=0, le=2)
-    h9190: int = Field(ge=0, le=2)
+    H9120: int = Field(ge=0, le=2)
+    H9190: int = Field(ge=0, le=2)
 
 
 NumberType = Union[int, float]

--- a/veg2hab/enums.py
+++ b/veg2hab/enums.py
@@ -20,6 +20,7 @@ class OBKWaarden(BaseModel):
     1 = bos in dit vlak komt mogelijk in aanmerking voor dit habitattype
     2 = bos in dit vlak komt in aanmerking voor dit habitattype
     """
+
     H9120: int = Field(ge=0, le=2)
     H9190: int = Field(ge=0, le=2)
 

--- a/veg2hab/enums.py
+++ b/veg2hab/enums.py
@@ -10,9 +10,11 @@ class BodemTuple(NamedTuple):
     codes: List[str]
     enkel_negatieven: bool
 
+
 class OBKWaarden(BaseModel):
     h9120: int = Field(ge=0, le=2)
     h9190: int = Field(ge=0, le=2)
+
 
 NumberType = Union[int, float]
 

--- a/veg2hab/enums.py
+++ b/veg2hab/enums.py
@@ -2,12 +2,17 @@ from dataclasses import dataclass
 from enum import Enum, IntEnum, auto
 from typing import List, NamedTuple, Tuple, Union
 
+from pydantic import BaseModel, Field
+
 
 class BodemTuple(NamedTuple):
     string: str
     codes: List[str]
     enkel_negatieven: bool
 
+class OBKWaarden(BaseModel):
+    h9120: int = Field(ge=0, le=2)
+    h9190: int = Field(ge=0, le=2)
 
 NumberType = Union[int, float]
 

--- a/veg2hab/enums.py
+++ b/veg2hab/enums.py
@@ -12,6 +12,14 @@ class BodemTuple(NamedTuple):
 
 
 class OBKWaarden(BaseModel):
+    """
+    # TODO: Deze definities even checken met Jakko
+
+    H9120 en H9190 waarden van de Oude Bossenkaart
+    0 = bos in dit vlak komt niet in aanmerking voor dit habitattype
+    1 = bos in dit vlak komt mogelijk in aanmerking voor dit habitattype
+    2 = bos in dit vlak komt in aanmerking voor dit habitattype
+    """
     H9120: int = Field(ge=0, le=2)
     H9190: int = Field(ge=0, le=2)
 

--- a/veg2hab/main.py
+++ b/veg2hab/main.py
@@ -6,7 +6,7 @@ from typing import Union
 import geopandas as gpd
 
 from veg2hab import constants
-from veg2hab.bronnen import FGR, LBK, Bodemkaart
+from veg2hab.bronnen import FGR, LBK, Bodemkaart, OudeBossenkaart
 from veg2hab.definitietabel import DefinitieTabel
 from veg2hab.io.common import (
     AccessDBInputs,
@@ -168,10 +168,15 @@ def run_3_definitietabel_en_mitsen(params: ApplyDefTabelInputs):
 
     logging.info(f"LBK is ingelezen")
 
+    obk = OudeBossenkaart(Path(constants.OUDE_BOSSENKAART_PATH))
+
+    logging.info(f"Oude bossenkaart is ingelezen van {constants.OUDE_BOSSENKAART_PATH}")
+
     kartering.bepaal_mits_habitatkeuzes(
         fgr,
         bodemkaart,
         lbk,
+        obk,
     )
 
     logging.info(f"Mitsen zijn gecheckt")

--- a/veg2hab/package_data/Oudebossen.gpkg
+++ b/veg2hab/package_data/Oudebossen.gpkg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:529e3b6c09ebfdd63806ac6d08b599cbdcfebc2b2424766e6e11470f3f396bbb
+size 3059712

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -12,11 +12,12 @@ from typing_extensions import Literal, Self
 
 from veg2hab import vegetatietypen
 from veg2hab.access_db import read_access_tables
-from veg2hab.bronnen import FGR, LBK, Bodemkaart
+from veg2hab.bronnen import FGR, LBK, Bodemkaart, OudeBossenkaart
 from veg2hab.criteria import (
     BodemCriterium,
     FGRCriterium,
     LBKCriterium,
+    OudeBossenCriterium,
     is_criteria_type_present,
 )
 from veg2hab.enums import KeuzeStatus, Kwaliteit
@@ -1096,7 +1097,9 @@ class Kartering:
         )
 
     # NOTE: Moeten fgr/bodemkaart/lbk optional zijn?
-    def check_mitsen(self, fgr: FGR, bodemkaart: Bodemkaart, lbk: LBK) -> None:
+    def check_mitsen(
+        self, fgr: FGR, bodemkaart: Bodemkaart, lbk: LBK, obk: OudeBossenkaart
+    ) -> None:
         """
         Checkt of de mitsen in de habitatvoorstellen van de kartering wordt voldaan.
         """
@@ -1117,6 +1120,9 @@ class Kartering:
         lbk_needed = self.gdf["HabitatVoorstel"].apply(
             is_criteria_type_present, args=(LBKCriterium,)
         )
+        obk_needed = self.gdf["HabitatVoorstel"].apply(
+            is_criteria_type_present, args=(OudeBossenCriterium,)
+        )
 
         ### Verrijken met de benodigde informatie
         if fgr_needed.any():
@@ -1127,6 +1133,8 @@ class Kartering:
             mits_info_df["bodem"] = bodemkaart.for_geometry(
                 mits_info_df.loc[bodem_needed]
             )
+        if obk_needed.any():
+            mits_info_df["obk"] = obk.for_geometry(mits_info_df.loc[obk_needed])
 
         ### Mitsen checken
         for idx, row in self.gdf.iterrows():
@@ -1138,7 +1146,7 @@ class Kartering:
                     voorstel.mits.check(mits_info_row)
 
     def bepaal_mits_habitatkeuzes(
-        self, fgr: FGR, bodemkaart: Bodemkaart, lbk: LBK
+        self, fgr: FGR, bodemkaart: Bodemkaart, lbk: LBK, obk: OudeBossenkaart
     ) -> None:
         """
         Bepaalt voor complexdelen zonder mozaiekregels de habitatkeuzes
@@ -1150,7 +1158,7 @@ class Kartering:
         ), f"bodemkaart moet een Bodemkaart object zijn, geen {type(bodemkaart)}"
         assert isinstance(lbk, LBK), f"lbk moet een LBK object zijn, geen {type(lbk)}"
 
-        self.check_mitsen(fgr, bodemkaart, lbk)
+        self.check_mitsen(fgr, bodemkaart, lbk, obk)
 
         self.gdf["HabitatKeuze"] = self.gdf["HabitatVoorstel"].apply(
             lambda voorstellen: [


### PR DESCRIPTION
Redelijk straightforward. 

- `mitsjson.json` is aangepast zodat het nieuwe criteria ook daadwerkelijk gebruikt wordt.
- `demo_criteria_opmerkingen.ipynb` is én gefixt zodat het weer mooi klopt met hoe nans aangegeven worden aan check(), én heeft nu ook een demo voor het oude bossen criteria.
- `test_criteria.py` test nu ook een aantal oude bossen cases
- `bronnen.py` heeft de benodigde nieuwe bronkaart
- `constants.py` heeft het pad naar de nieuwe bronkaart
- `criteria.py` heeft het nieuwe criteria. Volgt mooi dezelfde structuur als de anderen :)
- `enums.py` bevat de mooie nieuwe class waar de data uit de bronkaart in ingelezen wordt
- `Oudebossen.gpkg` heb ik maar lekker in package data gedaan want hij is nog kleiner dan de FGR (3MB vs 13.5MB)


Nog niet mergen, ik wacht nog even op antwoord van johannes over hoe zo'n groot deel van de mits we kunnen checken met het OudeBossenCriterium (of de "onderdeel van een minimaal honderdjarige opstand van zomereik"/"100 jarige bosopstand grenzend aan een bosgroeiplaats ouder dan 1850" NietGeautomatiseerdeCriteriums in `mitsjson.json` weg kunnen of niet)