### PR TITLE
SPH-829 - Naam vegtype en habtype in output

### DIFF
--- a/tests/test_deftabel_matching.py
+++ b/tests/test_deftabel_matching.py
@@ -57,6 +57,8 @@ def test_perfect_match_VvN(dt):
             ),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.ASSOCIATIE_VVN,
+            vegtype_in_dt_naam="Schorrekruid-associatie",
+            habtype_naam="Zilte pionierbegroeiingen (zeekraal)",
         )
     ]
     assert dt.find_habtypes(pre) == post
@@ -91,6 +93,8 @@ def test_match_to_less_specific_VvN(dt):
             ),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.ASSOCIATIE_VVN,
+            vegtype_in_dt_naam="Associatie van Klimopwaterranonkel",
+            habtype_naam="Beken en rivieren met waterplanten (waterranonkels)",
         )
     ]
     # Should match with 5ca2
@@ -110,6 +114,8 @@ def test_gemeenschap_perfect_match_VvN(dt):
             ),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.GEMEENSCHAP_VVN,
+            vegtype_in_dt_naam="Rompgemeenschap met Gewoon sterrekroos van de Orde van Haaksterrekroos en Grote waterranonkel",
+            habtype_naam="Beken en rivieren met waterplanten (waterranonkels)",
         )
     ]
     assert dt.find_habtypes(pre) == post
@@ -126,6 +132,8 @@ def test_match_to_multiple_perfect_matches_VvN(dt):
             mits=LBKCriterium(wanted_lbktype=LBKType.ZANDVERSTUIVING),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.SUBASSOCIATIE_VVN,
+            vegtype_in_dt_naam="Associatie van Schapegras en Tijm (subassociatie met Zandblauwtje)",
+            habtype_naam="Zandverstuivingen",
         ),
         HabitatVoorstel(
             onderbouwend_vegtype=VvN.from_code("14bb1a"),
@@ -137,6 +145,8 @@ def test_match_to_multiple_perfect_matches_VvN(dt):
             ),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.SUBASSOCIATIE_VVN,
+            vegtype_in_dt_naam="Associatie van Schapegras en Tijm (subassociatie met Zandblauwtje)",
+            habtype_naam="Stroomdalgraslanden",
         ),
     ]
 
@@ -159,6 +169,8 @@ def test_perfect_and_less_specific_match_VvN(dt):
             ),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.SUBASSOCIATIE_VVN,
+            vegtype_in_dt_naam="Associatie van Grauwe wilg (subassociatie met Hennegras)",
+            habtype_naam="Duinbossen (vochtig)",
         ),
         HabitatVoorstel(
             onderbouwend_vegtype=VvN.from_code("36aa2a"),
@@ -173,6 +185,8 @@ def test_perfect_and_less_specific_match_VvN(dt):
                 ook_als_rand_langs=True,
             ),
             match_level=MatchLevel.ASSOCIATIE_VVN,
+            vegtype_in_dt_naam="Associatie van Grauwe wilg",
+            habtype_naam="Hoogveenbossen",
         ),
     ]
     assert dt.find_habtypes(pre) == post
@@ -189,6 +203,8 @@ def test_perfect_match_SBB(dt):
             mits=NietGeautomatiseerdCriterium(toelichting="mits in vennen"),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.ASSOCIATIE_SBB,
+            vegtype_in_dt_naam="Associatie van Slangewortel",
+            habtype_naam="Zure vennen",
         )
     ]
     assert dt.find_habtypes(pre) == post
@@ -209,6 +225,8 @@ def test_matches_both_vvn_and_sbb(dt):
             ),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.GEMEENSCHAP_VVN,
+            vegtype_in_dt_naam="Rompgemeenschap met Gewoon sterrekroos van de Orde van Haaksterrekroos en Grote waterranonkel",
+            habtype_naam="Beken en rivieren met waterplanten (waterranonkels)",
         ),
         HabitatVoorstel(
             onderbouwend_vegtype=VvN.from_code("14bb1a"),
@@ -218,6 +236,8 @@ def test_matches_both_vvn_and_sbb(dt):
             mits=LBKCriterium(wanted_lbktype=LBKType.ZANDVERSTUIVING),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.SUBASSOCIATIE_VVN,
+            vegtype_in_dt_naam="Associatie van Schapegras en Tijm (subassociatie met Zandblauwtje)",
+            habtype_naam="Zandverstuivingen",
         ),
         HabitatVoorstel(
             onderbouwend_vegtype=VvN.from_code("14bb1a"),
@@ -229,6 +249,8 @@ def test_matches_both_vvn_and_sbb(dt):
             ),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.SUBASSOCIATIE_VVN,
+            vegtype_in_dt_naam="Associatie van Schapegras en Tijm (subassociatie met Zandblauwtje)",
+            habtype_naam="Stroomdalgraslanden",
         ),
         HabitatVoorstel(
             onderbouwend_vegtype=SBB.from_code("9b1"),
@@ -238,6 +260,8 @@ def test_matches_both_vvn_and_sbb(dt):
             mits=NietGeautomatiseerdCriterium(toelichting="mits in vennen"),
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.ASSOCIATIE_SBB,
+            vegtype_in_dt_naam="Associatie van Slangewortel",
+            habtype_naam="Zure vennen",
         ),
     ]
     post2 = dt.find_habtypes(pre)

--- a/veg2hab/habitat.py
+++ b/veg2hab/habitat.py
@@ -71,10 +71,7 @@ class HabitatVoorstel(BaseModel):
             match_level=MatchLevel.NO_MATCH,
         )
 
-    def get_VvNdftbl_str(self):
-        if isinstance(self.vegtype_in_dt, SBB):
-            return "---"
-
+    def _get_dftbl_str(self):
         veg_str = str(self.vegtype_in_dt)
         if self.vegtype_in_dt_naam != "":
             veg_str += f" ({self.vegtype_in_dt_naam})"
@@ -84,20 +81,18 @@ class HabitatVoorstel(BaseModel):
             hab_str += f" ({self.habtype_naam})"
 
         return f"[{veg_str}, {hab_str}]"
+
+    def get_VvNdftbl_str(self):
+        if isinstance(self.vegtype_in_dt, SBB):
+            return "---"
+
+        return self._get_dftbl_str()
 
     def get_SBBdftbl_str(self):
         if isinstance(self.vegtype_in_dt, VvN):
             return "---"
 
-        veg_str = str(self.vegtype_in_dt)
-        if self.vegtype_in_dt_naam != "":
-            veg_str += f" ({self.vegtype_in_dt_naam})"
-
-        hab_str = self.habtype
-        if self.habtype_naam != "":
-            hab_str += f" ({self.habtype_naam})"
-
-        return f"[{veg_str}, {hab_str}]"
+        return self._get_dftbl_str()
 
     @staticmethod
     def serialize_list2(voorstellen: List[List["HabitatVoorstel"]]) -> str:

--- a/veg2hab/habitat.py
+++ b/veg2hab/habitat.py
@@ -29,6 +29,8 @@ class HabitatVoorstel(BaseModel):
     mits: BeperkendCriterium
     mozaiek: MozaiekRegel
     match_level: MatchLevel
+    vegtype_in_dt_naam: str = ""
+    habtype_naam: str = ""
 
     @classmethod
     def H0000_vegtype_not_in_dt(cls, info: "VegTypeInfo"):
@@ -68,6 +70,34 @@ class HabitatVoorstel(BaseModel):
             mozaiek=GeenMozaiekregel(),
             match_level=MatchLevel.NO_MATCH,
         )
+
+    def get_VvNdftbl_str(self):
+        if isinstance(self.vegtype_in_dt, SBB):
+            return "---"
+
+        veg_str = str(self.vegtype_in_dt)
+        if self.vegtype_in_dt_naam != "":
+            veg_str += f" ({self.vegtype_in_dt_naam})"
+
+        hab_str = self.habtype
+        if self.habtype_naam != "":
+            hab_str += f" ({self.habtype_naam})"
+
+        return f"[{veg_str}, {hab_str}]"
+
+    def get_SBBdftbl_str(self):
+        if isinstance(self.vegtype_in_dt, VvN):
+            return "---"
+
+        veg_str = str(self.vegtype_in_dt)
+        if self.vegtype_in_dt_naam != "":
+            veg_str += f" ({self.vegtype_in_dt_naam})"
+
+        hab_str = self.habtype
+        if self.habtype_naam != "":
+            hab_str += f" ({self.habtype_naam})"
+
+        return f"[{veg_str}, {hab_str}]"
 
     @staticmethod
     def serialize_list2(voorstellen: List[List["HabitatVoorstel"]]) -> str:

--- a/veg2hab/package_data/opgeschoonde_definitietabel.xlsx
+++ b/veg2hab/package_data/opgeschoonde_definitietabel.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94efcf8734afe563d5c130210cf5e658b26781a80394d2cd4a2e8af7f4f6d727
-size 35053
+oid sha256:fdc9f5c732617c51bb6d84d5af79334837bde50c5f2a5ee4d1aac4e3733b0b0a
+size 49782

--- a/veg2hab/package_data/opgeschoonde_waswordt.xlsx
+++ b/veg2hab/package_data/opgeschoonde_waswordt.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29bcf28fd9a5f9e00e30d3713d3b287ee9860219aafc90b76982e371b8a693e9
-size 26586
+oid sha256:c44b37f169429808448a7f60f8681055bb0879ae2bb4896aab0cd6eff334558d
+size 26589

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -332,22 +332,8 @@ def hab_as_final_format(print_info: tuple, idx: int, opp: float) -> pd.Series:
                 # f"VEGlok{idx}" TODO: Doen we voor nu nog even niet
                 f"_Status{idx}": str(keuze.status),
                 f"_Uitleg{idx}": keuze.status.toelichting,
-                f"_VvNdftbl{idx}": str(
-                    [
-                        str(voorstel.vegtype_in_dt),
-                        voorstel.habtype,
-                    ]
-                    if isinstance(voorstel.vegtype_in_dt, vegetatietypen.VvN)
-                    else None
-                ),
-                f"_SBBdftbl{idx}": str(
-                    [
-                        str(voorstel.vegtype_in_dt),
-                        voorstel.habtype,
-                    ]
-                    if isinstance(voorstel.vegtype_in_dt, vegetatietypen.SBB)
-                    else None
-                ),
+                f"_VvNdftbl{idx}": voorstel.get_VvNdftbl_str(),
+                f"_SBBdftbl{idx}": voorstel.get_SBBdftbl_str(),
             }
 
             return pd.Series(series_dict)
@@ -384,34 +370,10 @@ def hab_as_final_format(print_info: tuple, idx: int, opp: float) -> pd.Series:
             f"_Status{idx}": str(keuze.status),
             f"_Uitleg{idx}": keuze.status.toelichting,
             f"_VvNdftbl{idx}": "\n".join(
-                [
-                    (
-                        str(
-                            [
-                                str(voorstel.vegtype_in_dt),
-                                voorstel.habtype,
-                            ]
-                        )
-                        if isinstance(voorstel.vegtype_in_dt, vegetatietypen.VvN)
-                        else "---"
-                    )
-                    for voorstel in voorstellen
-                ]
+                [voorstel.get_VvNdftbl_str() for voorstel in voorstellen]
             ),
             f"_SBBdftbl{idx}": "\n".join(
-                [
-                    (
-                        str(
-                            [
-                                str(voorstel.vegtype_in_dt),
-                                voorstel.habtype,
-                            ]
-                        )
-                        if isinstance(voorstel.vegtype_in_dt, vegetatietypen.SBB)
-                        else "---"
-                    )
-                    for voorstel in voorstellen
-                ]
+                [voorstel.get_SBBdftbl_str() for voorstel in voorstellen]
             ),
         }
 


### PR DESCRIPTION
De naam wordt bij het matchen aan de deftabel uit de deftabel gehaald; hiervoor heb ik de kolommen met de namen in de opgeschoonde deftabel overgenomen.

Ik heb meteen ook het maken van de SBB/VvNdftbl strings verplaatst naar HabitatVoorstel, aangezien het anders wel veel gechoogel zou worden in hab_as_final_format.

Voorbeeldjes van de nieuwe output:

-----

[9aa2 (Veenmosrietland), H7140_B (Overgangs- en trilvenen (veenmosrietlanden))]

-----

[50a (vegetatieloos), H7110_A (Actieve hoogvenen (hoogveenlandschap))]
[50a (bronvegetatie met beekdikkopmos, geveerd diknerfmos en/of gewoon diknerfmos), H7220 (Kalktufbronnen)]

-----

[9rg2 (Rompgemeenschap met Zwarte zegge en Moerasstruisgras van het Verbond van Zwarte zegge), H2190_C (Vochtige duinvalleien (ontkalkt))]
[9rg2 (Rompgemeenschap met Zwarte zegge en Moerasstruisgras van het Verbond van Zwarte zegge), H7140_A (Overgangs- en trilvenen (trilvenen))]
[9rg2 (Rompgemeenschap met Zwarte zegge en Moerasstruisgras van het Verbond van Zwarte zegge), H7140_B (Overgangs- en trilvenen (veenmosrietlanden))]
[9rg2 (Rompgemeenschap met Zwarte zegge en Moerasstruisgras van het Verbond van Zwarte zegge), H7150 (Pioniervegetaties met snavelbiezen)]

-----