### PR TITLE
SPH-936 - Bronvlakoverlap staat in de output

### DIFF
--- a/notebooks/demo_criteria_opmerkingen.ipynb
+++ b/notebooks/demo_criteria_opmerkingen.ipynb
@@ -2,23 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/jordydelange/.cache/pypoetry/virtualenvs/veg2hab-CuqoUkZb-py3.7/lib/python3.7/site-packages/geopandas/_compat.py:115: UserWarning: The Shapely GEOS version (3.11.2-CAPI-1.17.2) is incompatible with the GEOS version PyGEOS was compiled with (3.10.4-CAPI-1.16.2). Conversions between both will be slow.\n",
-      "  shapely_geos_version, geos_capi_version_string\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from veg2hab.criteria import FGRCriterium, LBKCriterium, BodemCriterium, EnCriteria, NietCriterium, OfCriteria\n",
-    "from veg2hab.enums import FGRType, LBKType, BodemType, LBKTuple\n",
+    "from veg2hab.enums import FGRType, LBKType, BodemType\n",
     "import pandas as pd\n",
-    "from enum import Enum"
+    "from enum import Enum\n",
+    "import random"
    ]
   },
   {
@@ -30,33 +22,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "FGRType.DU\n",
-      "TRUE\n",
-      "{'FGR type is Duinen.'}\n",
-      "--------\n",
-      "FGRType.HL\n",
-      "FALSE\n",
-      "{'FGR type is niet Duinen, maar Heuvelland.'}\n",
-      "--------\n",
-      "<NA>\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één FGR-vlak.'}\n",
-      "--------\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "du = FGRCriterium(wanted_fgrtype=FGRType.DU)\n",
     "\n",
     "for fgr_type in [FGRType.DU, FGRType.HL, pd.NA]:\n",
-    "    row = pd.Series({\"fgr\": fgr_type})\n",
+    "    row = pd.Series({\"fgr\": fgr_type, \"fgr_percentage\": random.randint(0, 100)})\n",
     "    du.check(row)\n",
     "    print(fgr_type)\n",
     "    print(du.evaluation)\n",
@@ -73,33 +46,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['Zn21']\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "{'Dit is mogelijk Leemarme vaaggronden want bodemcode Zn21.'}\n",
-      "--------\n",
-      "['Abcd']\n",
-      "FALSE\n",
-      "{'Dit is niet Leemarme vaaggronden want bodemcode Abcd.'}\n",
-      "--------\n",
-      "[<NA>]\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak.'}\n",
-      "--------\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "lv = BodemCriterium(wanted_bodemtype=BodemType.LEEMARME_VAAGGRONDEN_H9190)\n",
     "\n",
-    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], [pd.NA]]:\n",
-    "    row = pd.Series({\"bodem\": bodem_code})\n",
+    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], pd.NA]:\n",
+    "    row = pd.Series({\"bodem\": bodem_code, \"bodem_percentage\": random.randint(0, 100)})\n",
     "    lv.check(row)\n",
     "    print(bodem_code)\n",
     "    print(lv.evaluation)\n",
@@ -116,33 +70,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['Zn21']\n",
-      "TRUE\n",
-      "{'Dit is Vaaggronden want bodemcode Zn21.'}\n",
-      "--------\n",
-      "['Abcd']\n",
-      "FALSE\n",
-      "{'Dit is niet Vaaggronden want bodemcode Abcd.'}\n",
-      "--------\n",
-      "[<NA>]\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één bodemkaartvlak.'}\n",
-      "--------\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "vg = BodemCriterium(wanted_bodemtype=BodemType.VAAGGRONDEN)\n",
     "\n",
-    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], [pd.NA]]:\n",
-    "    row = pd.Series({\"bodem\": bodem_code})\n",
+    "for bodem_code in [[\"Zn21\"], [\"Abcd\"], pd.NA]:\n",
+    "    row = pd.Series({\"bodem\": bodem_code, \"bodem_percentage\": random.randint(0, 100)})\n",
     "    vg.check(row)\n",
     "    print(bodem_code)\n",
     "    print(vg.evaluation)\n",
@@ -159,33 +94,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "HzHL\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "{'Dit is mogelijk Herstellend hoogveen want LBK code HzHL.'}\n",
-      "--------\n",
-      "Abcd\n",
-      "FALSE\n",
-      "{'Dit is niet Herstellend hoogveen want LBK code Abcd.'}\n",
-      "--------\n",
-      "<NA>\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één LBK-vak'}\n",
-      "--------\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "hh = LBKCriterium(wanted_lbktype=LBKType.HERSTELLEND_HOOGVEEN)\n",
     "\n",
     "for lbk_code in [\"HzHL\", \"Abcd\", pd.NA]:\n",
-    "    row = pd.Series({\"lbk\": lbk_code})\n",
+    "    row = pd.Series({\"lbk\": lbk_code, \"lbk_percentage\": random.randint(0, 100)})\n",
     "    hh.check(row)\n",
     "    print(lbk_code)\n",
     "    print(hh.evaluation)\n",
@@ -202,33 +118,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "HzHL\n",
-      "TRUE\n",
-      "{'Dit is Hoogveenlandschap want LBK code HzHL.'}\n",
-      "--------\n",
-      "Abcd\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "{'Dit is mogelijk toch Hoogveenlandschap ondanks LBK code Abcd.'}\n",
-      "--------\n",
-      "<NA>\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "{'Dit vlak ligt niet mooi binnen één LBK-vak'}\n",
-      "--------\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "hl = LBKCriterium(wanted_lbktype=LBKType.HOOGVEENLANDSCHAP)\n",
     "\n",
     "for lbk_code in [\"HzHL\", \"Abcd\", pd.NA]:\n",
-    "    row = pd.Series({\"lbk\": lbk_code})\n",
+    "    row = pd.Series({\"lbk\": lbk_code, \"lbk_percentage\": random.randint(0, 100)})\n",
     "    hl.check(row)\n",
     "    print(lbk_code)\n",
     "    print(hl.evaluation)\n",
@@ -245,36 +142,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "((LBK is Herstellend hoogveen (C) of LBK is Hoogveenlandschap (T) of Bodem is Leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (F))\n",
-      "TRUE\n",
-      "Dit is Hoogveenlandschap want LBK code HzHL.\n",
-      "FGR type is niet Laagveengebied, maar Duinen.\n",
-      "Dit is niet Leemarme humuspodzolgronden want bodemcode Zn21.\n",
-      "Dit is mogelijk Herstellend hoogveen want LBK code HzHL.\n",
-      "--------\n",
-      "((LBK is Herstellend hoogveen (F) of LBK is Hoogveenlandschap (C) of Bodem is Leemarme humuspodzolgronden (F)) en niet FGR is Laagveengebied (T))\n",
-      "FALSE\n",
-      "Dit is niet Herstellend hoogveen want LBK code Abcd.\n",
-      "Dit is mogelijk toch Hoogveenlandschap ondanks LBK code Abcd.\n",
-      "Dit is niet Leemarme humuspodzolgronden want bodemcode Abcd.\n",
-      "FGR type is Laagveengebied.\n",
-      "--------\n",
-      "((LBK is Herstellend hoogveen (C) of LBK is Hoogveenlandschap (C) of Bodem is Leemarme humuspodzolgronden (C)) en niet FGR is Laagveengebied (C))\n",
-      "CANNOT_BE_AUTOMATED\n",
-      "Dit vlak ligt niet mooi binnen één FGR-vlak.\n",
-      "Dit vlak ligt niet mooi binnen één bodemkaartvlak.\n",
-      "Dit vlak ligt niet mooi binnen één LBK-vak\n",
-      "--------\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "crit = EnCriteria(\n",
     "    sub_criteria=\n",
@@ -292,8 +162,8 @@
     "    ]\n",
     ")\n",
     "\n",
-    "for lbk_code, fgr_code, bodem_code in [(\"HzHL\", FGRType.DU, [\"Zn21\"]), (\"Abcd\", FGRType.LV, [\"Abcd\"]), (pd.NA, pd.NA, [pd.NA])]:\n",
-    "    row = pd.Series({\"lbk\": lbk_code, \"fgr\": fgr_code, \"bodem\": bodem_code})\n",
+    "for lbk_code, fgr_code, bodem_code in [(\"HzHL\", FGRType.DU, [\"Zn21\"]), (\"Abcd\", FGRType.LV, [\"Abcd\"]), (pd.NA, pd.NA, pd.NA)]:\n",
+    "    row = pd.Series({\"lbk\": lbk_code, \"lbk_percentage\": random.randint(0, 100), \"fgr\": fgr_code, \"fgr_percentage\": random.randint(0, 100), \"bodem\": bodem_code, \"bodem_percentage\": random.randint(0, 100)})\n",
     "    crit.check(row)\n",
     "    print(str(crit))\n",
     "    print(crit.evaluation)\n",

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -25,10 +25,10 @@ def test_GeenCriterium():
 def test_FGRCriterium():
     crit = FGRCriterium(wanted_fgrtype=FGRType.DU)
     assert crit.wanted_fgrtype == FGRType.DU
-    row = pd.Series({"fgr": FGRType.DU})
+    row = pd.Series({"fgr": FGRType.DU, "fgr_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.TRUE
-    row = pd.Series({"fgr": FGRType.LV})
+    row = pd.Series({"fgr": FGRType.LV, "fgr_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
 
@@ -36,11 +36,11 @@ def test_FGRCriterium():
 def test_LBKCriterium_enkel_negatieven():
     crit = LBKCriterium(wanted_lbktype=LBKType.HOOGVEEN)
     assert crit.wanted_lbktype == LBKType.HOOGVEEN
-    row = pd.Series({"lbk": "HzHL"})
+    row = pd.Series({"lbk": "HzHL", "lbk_percentage": 100})
     crit.check(row)
     assert crit.wanted_lbktype.enkel_negatieven == True
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
-    row = pd.Series({"lbk": "Abcd"})
+    row = pd.Series({"lbk": "Abcd", "lbk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
 
@@ -48,11 +48,11 @@ def test_LBKCriterium_enkel_negatieven():
 def test_LBKCriterium_enkel_positieven():
     crit = LBKCriterium(wanted_lbktype=LBKType.HOOGVEENLANDSCHAP)
     assert crit.wanted_lbktype == LBKType.HOOGVEENLANDSCHAP
-    row = pd.Series({"lbk": "HzHL"})
+    row = pd.Series({"lbk": "HzHL", "lbk_percentage": 100})
     crit.check(row)
     assert crit.wanted_lbktype.enkel_positieven == True
     assert crit.evaluation == MaybeBoolean.TRUE
-    row = pd.Series({"lbk": "Abcd"})
+    row = pd.Series({"lbk": "Abcd", "lbk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
 
@@ -60,14 +60,14 @@ def test_LBKCriterium_enkel_positieven():
 def test_BodemCriterium_normaal():
     crit = BodemCriterium(wanted_bodemtype=BodemType.LEEMARME_HUMUSPODZOLGRONDEN)
     assert crit.wanted_bodemtype == BodemType.LEEMARME_HUMUSPODZOLGRONDEN
-    row = pd.Series({"bodem": ["Hn21"]})
+    row = pd.Series({"bodem": ["Hn21"], "bodem_percentage": 100})
     crit.check(row)
     assert crit.wanted_bodemtype.enkel_negatieven == False
     assert crit.evaluation == MaybeBoolean.TRUE
-    row = pd.Series({"bodem": ["Abcd"]})
+    row = pd.Series({"bodem": ["Abcd"], "bodem_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
-    row = pd.Series({"bodem": ["Abcd", "Hn21"]})
+    row = pd.Series({"bodem": ["Abcd", "Hn21"], "bodem_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
 
@@ -75,11 +75,11 @@ def test_BodemCriterium_normaal():
 def test_BodemCriterium_enkel_negatieven():
     crit = BodemCriterium(wanted_bodemtype=BodemType.LEEMARME_VAAGGRONDEN_H9190)
     assert crit.wanted_bodemtype == BodemType.LEEMARME_VAAGGRONDEN_H9190
-    row = pd.Series({"bodem": ["Zn21"]})
+    row = pd.Series({"bodem": ["Zn21"], "bodem_percentage": 100})
     crit.check(row)
     assert crit.wanted_bodemtype.enkel_negatieven == True
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
-    row = pd.Series({"bodem": ["Abcd"]})
+    row = pd.Series({"bodem": ["Abcd"], "bodem_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
 
@@ -91,7 +91,7 @@ def test_EnCriteria():
             FGRCriterium(wanted_fgrtype=FGRType.LV),
         ]
     )
-    row = pd.Series({"fgr": FGRType.DU})
+    row = pd.Series({"fgr": FGRType.DU, "fgr_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
     crit = EnCriteria(
@@ -100,7 +100,7 @@ def test_EnCriteria():
             FGRCriterium(wanted_fgrtype=FGRType.DU),
         ]
     )
-    row = pd.Series({"fgr": FGRType.DU})
+    row = pd.Series({"fgr": FGRType.DU, "fgr_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.TRUE
 
@@ -112,7 +112,7 @@ def test_OfCriteria():
             FGRCriterium(wanted_fgrtype=FGRType.LV),
         ]
     )
-    row = pd.Series({"fgr": FGRType.DU})
+    row = pd.Series({"fgr": FGRType.DU, "fgr_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.TRUE
     crit = OfCriteria(
@@ -121,17 +121,17 @@ def test_OfCriteria():
             FGRCriterium(wanted_fgrtype=FGRType.DU),
         ]
     )
-    row = pd.Series({"fgr": FGRType.LV})
+    row = pd.Series({"fgr": FGRType.LV, "fgr_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
 
 
 def test_NietCriterium():
     crit = NietCriterium(sub_criterium=FGRCriterium(wanted_fgrtype=FGRType.DU))
-    row = pd.Series({"fgr": FGRType.DU})
+    row = pd.Series({"fgr": FGRType.DU, "fgr_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
-    row = pd.Series({"fgr": FGRType.LV})
+    row = pd.Series({"fgr": FGRType.LV, "fgr_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.TRUE
 

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -87,33 +87,33 @@ def test_BodemCriterium_enkel_negatieven():
 
 def test_OudeBossenCriterium():
     crit = OudeBossenCriterium(for_habtype="H9120")
-    row = pd.Series({"obk": pd.NA})
+    row = pd.Series({"obk": pd.NA, "obk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
-    row = pd.Series({"obk": OBKWaarden(H9120=0, H9190=0)})
+    row = pd.Series({"obk": OBKWaarden(H9120=0, H9190=0), "obk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
 
     # for_habtype = H9120
-    row = pd.Series({"obk": OBKWaarden(H9120=1, H9190=0)})
+    row = pd.Series({"obk": OBKWaarden(H9120=1, H9190=0), "obk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
-    row = pd.Series({"obk": OBKWaarden(H9120=0, H9190=1)})
+    row = pd.Series({"obk": OBKWaarden(H9120=0, H9190=1), "obk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
-    row = pd.Series({"obk": OBKWaarden(H9120=2, H9190=2)})
+    row = pd.Series({"obk": OBKWaarden(H9120=2, H9190=2), "obk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
 
     # for_habtype = H9190
     crit = OudeBossenCriterium(for_habtype="H9190")
-    row = pd.Series({"obk": OBKWaarden(H9120=1, H9190=0)})
+    row = pd.Series({"obk": OBKWaarden(H9120=1, H9190=0), "obk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.FALSE
-    row = pd.Series({"obk": OBKWaarden(H9120=0, H9190=1)})
+    row = pd.Series({"obk": OBKWaarden(H9120=0, H9190=1), "obk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
-    row = pd.Series({"obk": OBKWaarden(H9120=2, H9190=2)})
+    row = pd.Series({"obk": OBKWaarden(H9120=2, H9190=2), "obk_percentage": 100})
     crit.check(row)
     assert crit.evaluation == MaybeBoolean.CANNOT_BE_AUTOMATED
 

--- a/veg2hab/bronnen.py
+++ b/veg2hab/bronnen.py
@@ -55,9 +55,13 @@ def get_datadir(app_author: str, app_name: str) -> Path:
 
 def sjoin_largest_overlap(
     kartering_gdf: gpd.GeoDataFrame, bron_gdf: gpd.GeoDataFrame, bron_col_name: str
-) -> gpd.GeoSeries:
+) -> gpd.GeoDataFrame:
     """
-    Voegt de kolommen van bron_gdf toe aan kartering_gdf op basis van de grootste overlap.
+    Zoekt voor elk karteringvlak de bronvlakken waar het het meeste mee overlapt.
+
+    Geeft een geodataframe terug met daarin voor ieder vlak in kartering_gdf
+    de info uit bron_gdf waar het het meeste mee overlapt (in kolom bron_col_name)
+    en het percentage van het karteringvlak dat overlapt met het bronvlak.
     """
     assert (
         bron_col_name in bron_gdf.columns

--- a/veg2hab/bronnen.py
+++ b/veg2hab/bronnen.py
@@ -93,6 +93,11 @@ def sjoin_largest_overlap(
     # Groupby index, zodat we groepen maken per karteringvlak
     grouped = joined.groupby(level=0, group_keys=False)
     only_largest_overlaps = grouped.apply(_retain_largest_overlap_area_row)
+    only_largest_overlaps[f"{bron_col_name}_percentage"] = (
+        only_largest_overlaps["overlap_area"]
+        / only_largest_overlaps["geometry"].area
+        * 100
+    )
 
     bron_gdf = bron_gdf.drop(columns=["geometry_bron"])
 
@@ -100,7 +105,7 @@ def sjoin_largest_overlap(
         kartering_gdf
     ), "DF met bronvlakcodes moet even lang zijn als de kartering_gdf"
 
-    return only_largest_overlaps[bron_col_name]
+    return only_largest_overlaps[[bron_col_name, f"{bron_col_name}_percentage"]]
 
 
 class LBK:

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -114,7 +114,7 @@ class FGRCriterium(BeperkendCriterium):
     type: ClassVar[str] = "FGRCriterium"
     wanted_fgrtype: FGRType
     actual_fgrtype: Optional[FGRType] = None
-    overlap_percentage: float = 0
+    overlap_percentage: float = 0.0
     cached_evaluation: Optional[MaybeBoolean] = None
 
     def check(self, row: gpd.GeoSeries) -> None:
@@ -173,7 +173,7 @@ class BodemCriterium(BeperkendCriterium):
     type: ClassVar[str] = "BodemCriterium"
     wanted_bodemtype: BodemType
     actual_bodemcode: Optional[List[str]] = None
-    overlap_percentage: float = 0
+    overlap_percentage: float = 0.0
     cached_evaluation: Optional[MaybeBoolean] = None
 
     def check(self, row: gpd.GeoSeries) -> None:
@@ -251,7 +251,7 @@ class LBKCriterium(BeperkendCriterium):
     type: ClassVar[str] = "LBKCriterium"
     wanted_lbktype: LBKType
     actual_lbkcode: Optional[str] = None
-    overlap_percentage: float = 0
+    overlap_percentage: float = 0.0
     cached_evaluation: Optional[MaybeBoolean] = None
 
     def check(self, row: gpd.GeoSeries) -> None:
@@ -342,7 +342,7 @@ class OudeBossenCriterium(BeperkendCriterium):
     # vlak liggen (dan geven we MaybeBoolean.CANNOT_BE_AUTOMATED terug), hebben
     # we geen target/wanted waarden nodig.
     actual_OBK: Optional[OBKWaarden] = None
-    overlap_percentage: float = 0
+    overlap_percentage: float = 0.0
     cached_evaluation: Optional[MaybeBoolean] = None
 
     def check(self, row: gpd.GeoSeries) -> None:
@@ -355,6 +355,7 @@ class OudeBossenCriterium(BeperkendCriterium):
         geven we MaybeBoolean.CANNOT_BE_AUTOMATED terug.
         """
         assert "obk" in row, "obk kolom niet aanwezig"
+        assert "obk_percentage" in row, "obk_percentage kolom niet aanwezig"
         assert self.for_habtype in [
             "H9120",
             "H9190",
@@ -398,7 +399,9 @@ class OudeBossenCriterium(BeperkendCriterium):
                 "niet binnen boskaartvlak"
                 if self.actual_OBK is None
                 else f"binnen boskaartvlak (H9120: {self.actual_OBK.H9120}, H9190: {self.actual_OBK.H9190})",
-                f" ({self.overlap_percentage:.1f}%)" if self.actual_OBK is not None else "",
+                f" ({self.overlap_percentage:.1f}%)"
+                if self.actual_OBK is not None
+                else "",
             )
         }
 

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -112,6 +112,7 @@ class NietGeautomatiseerdCriterium(BeperkendCriterium):
 
 # NOTE: Mogelijk een GeoCriteria baseclass maken FGR/LBK/Bodem/OBK criteria?
 
+
 class FGRCriterium(BeperkendCriterium):
     type: ClassVar[str] = "FGRCriterium"
     wanted_fgrtype: FGRType
@@ -351,7 +352,7 @@ class OudeBossenCriterium(BeperkendCriterium):
         Als de waarde van de obk kolom niet None is, dan is het vlak binnen een oude bossenkaartvlak.
         In dit geval kijken we naar de waarde van de obk kolom voor het for_habtype habitattype (H9120 of H9190).
         Is dit 0, dan is het vlak niet binnen een kwalificerend oud bos, dus geven we MaybeBoolean.FALSE terug.
-        Is dit 1 of 2, dan is het aan de gebruiker om te bepalen of het daadwerkelijk binnen een oud bos is, 
+        Is dit 1 of 2, dan is het aan de gebruiker om te bepalen of het daadwerkelijk binnen een oud bos is,
         dus geven we MaybeBoolean.CANNOT_BE_AUTOMATED terug.
         """
         assert "obk" in row, "obk kolom niet aanwezig"

--- a/veg2hab/criteria.py
+++ b/veg2hab/criteria.py
@@ -110,6 +110,8 @@ class NietGeautomatiseerdCriterium(BeperkendCriterium):
         return set()
 
 
+# NOTE: Mogelijk een GeoCriteria baseclass maken FGR/LBK/Bodem/OBK criteria?
+
 class FGRCriterium(BeperkendCriterium):
     type: ClassVar[str] = "FGRCriterium"
     wanted_fgrtype: FGRType
@@ -337,10 +339,6 @@ class LBKCriterium(BeperkendCriterium):
 class OudeBossenCriterium(BeperkendCriterium):
     type: ClassVar[str] = "OudeBossenCriterium"
     for_habtype: Literal["H9120", "H9190"]
-
-    # Aangezien we altijd MaybeBoolean.FALSE teruggeven tenzij we in een oude bossenkaart
-    # vlak liggen (dan geven we MaybeBoolean.CANNOT_BE_AUTOMATED terug), hebben
-    # we geen target/wanted waarden nodig.
     actual_OBK: Optional[OBKWaarden] = None
     overlap_percentage: float = 0.0
     cached_evaluation: Optional[MaybeBoolean] = None
@@ -350,9 +348,11 @@ class OudeBossenCriterium(BeperkendCriterium):
         Als de waarde van de obk kolom None is, dan is het vlak niet binnen een oude bossenkaartvlak,
         dus kunnen we veilig MaybeBoolean.FALSE teruggeven.
 
-        Als de waarde van de obk kolom niet None is, dan is het vlak binnen een oude bossenkaartvlak,
-        en is het aan de gebruiker om te bepalen of het daadwerkelijk binnen een oud bos is, dus
-        geven we MaybeBoolean.CANNOT_BE_AUTOMATED terug.
+        Als de waarde van de obk kolom niet None is, dan is het vlak binnen een oude bossenkaartvlak.
+        In dit geval kijken we naar de waarde van de obk kolom voor het for_habtype habitattype (H9120 of H9190).
+        Is dit 0, dan is het vlak niet binnen een kwalificerend oud bos, dus geven we MaybeBoolean.FALSE terug.
+        Is dit 1 of 2, dan is het aan de gebruiker om te bepalen of het daadwerkelijk binnen een oud bos is, 
+        dus geven we MaybeBoolean.CANNOT_BE_AUTOMATED terug.
         """
         assert "obk" in row, "obk kolom niet aanwezig"
         assert "obk_percentage" in row, "obk_percentage kolom niet aanwezig"

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -1219,7 +1219,7 @@ class Kartering:
             is_criteria_type_present, args=(OudeBossenCriterium,)
         )
 
-        ### Verrijken met de benodigde informatie
+        ### Verrijken met de benodigde informatie (joins zijn op index)
         if fgr_needed.any():
             mits_info_df = mits_info_df.join(
                 fgr.for_geometry(mits_info_df.loc[fgr_needed])

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -1215,12 +1215,16 @@ class Kartering:
 
         ### Verrijken met de benodigde informatie
         if fgr_needed.any():
-            mits_info_df["fgr"] = fgr.for_geometry(mits_info_df.loc[fgr_needed])
+            mits_info_df = mits_info_df.join(
+                fgr.for_geometry(mits_info_df.loc[fgr_needed])
+            )
         if lbk_needed.any():
-            mits_info_df["lbk"] = lbk.for_geometry(mits_info_df.loc[lbk_needed])
+            mits_info_df = mits_info_df.join(
+                lbk.for_geometry(mits_info_df.loc[lbk_needed])
+            )
         if bodem_needed.any():
-            mits_info_df["bodem"] = bodemkaart.for_geometry(
-                mits_info_df.loc[bodem_needed]
+            mits_info_df = mits_info_df.join(
+                bodemkaart.for_geometry(mits_info_df.loc[bodem_needed])
             )
 
         ### Mitsen checken


### PR DESCRIPTION
Ipv enkel de broninfo doorgeven vanuit bron.for_geometry(), krijg je nu ook het overlap percentage terug. Deze wordt in het criteria opgeslagen, en weergegeven in de get_opm() van de criteria.

Voorbeeldje:

FGR type is niet Duinen, maar Heuvelland (86.0%).

Dit is niet Herstellend hoogveen want LBK code Abcd (69.0%). 

Voor meer demo zie demo_criteria_opmerkingen.ipynb