### PR TITLE
SPH-948 - ArcGIS stap 2 fixen

### DIFF
--- a/veg2hab/functionele_samenhang.py
+++ b/veg2hab/functionele_samenhang.py
@@ -225,8 +225,25 @@ def _remove_habtypen_due_to_minimum_oppervlak(
         keuzes = gdf.loc[gdf.ElmID == ElmID, "HabitatKeuze"].iloc[0]
         for index in indices:
             keuze_to_be_edited = keuzes[index]
+            assert not keuze_to_be_edited.habtype in [
+                "H0000",
+                "HXXXX",
+            ], "H0000 en HXXXX vlakken zouden uitgesloten moeten zijn van functionele samenhang"
+            assert keuze_to_be_edited.kwaliteit in [
+                Kwaliteit.GOED,
+                Kwaliteit.MATIG,
+            ], "Functionele Samenhangvlak kwaliteit moet GOED of MATIG zijn"
+
             keuze_to_be_edited.status = KeuzeStatus.MINIMUM_OPP_NIET_GEHAALD
-            keuze_to_be_edited.opmerking = f"Was {keuze_to_be_edited.habtype}, maar oppervlak was te klein.{' ' + keuze_to_be_edited.opmerking if keuze_to_be_edited.opmerking is not None else ''}"
+            keuze_to_be_edited.opmerking = (
+                "Was {} {}, maar oppervlak was te klein.{}".format(
+                    keuze_to_be_edited.habtype,
+                    "(" + keuze_to_be_edited.kwaliteit.as_letter() + ")",
+                    f" {keuze_to_be_edited.opmerking}"
+                    if keuze_to_be_edited.opmerking is not None
+                    else "",
+                )
+            )
             keuze_to_be_edited.habtype = "H0000"
             keuze_to_be_edited.kwaliteit = Kwaliteit.NVT
 

--- a/veg2hab/functionele_samenhang.py
+++ b/veg2hab/functionele_samenhang.py
@@ -3,7 +3,7 @@ from typing import List, Set, Tuple
 import geopandas as gpd
 import pandas as pd
 
-from veg2hab.enums import FuncSamenhangID, KeuzeStatus
+from veg2hab.enums import FuncSamenhangID, KeuzeStatus, Kwaliteit
 from veg2hab.io.common import Interface
 
 
@@ -226,8 +226,9 @@ def _remove_habtypen_due_to_minimum_oppervlak(
         for index in indices:
             keuze_to_be_edited = keuzes[index]
             keuze_to_be_edited.status = KeuzeStatus.MINIMUM_OPP_NIET_GEHAALD
-            keuze_to_be_edited.opmerking = f"Was {keuze_to_be_edited.habtype}, maar oppervlak was te klein. {keuze_to_be_edited.opmerking}"
+            keuze_to_be_edited.opmerking = f"Was {keuze_to_be_edited.habtype}, maar oppervlak was te klein.{' ' + keuze_to_be_edited.opmerking if keuze_to_be_edited.opmerking is not None else ''}"
             keuze_to_be_edited.habtype = "H0000"
+            keuze_to_be_edited.kwaliteit = Kwaliteit.NVT
 
     return gdf
 

--- a/veg2hab/main.py
+++ b/veg2hab/main.py
@@ -149,9 +149,9 @@ def run_2_stack_vegkartering(params: StackVegKarteringInputs):
     logging.info("Karteringen zijn succesvol ingelezen")
 
     # Lijst reversen zodat de 'bovenste' kartering aan het einde komt
-    gdf_vegkart = Kartering.combineer_karteringen(
-        karteringen.reverse()
-    ).to_editable_vegtypes()
+    karteringen.reverse()
+
+    gdf_vegkart = Kartering.combineer_karteringen(karteringen).to_editable_vegtypes()
 
     logging.info("Karteringen zijn succesvol gestacked")
 

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -1289,7 +1289,9 @@ class Kartering:
                 bodemkaart.for_geometry(mits_info_df.loc[bodem_needed])
             )
         if obk_needed.any():
-            mits_info_df["obk"] = obk.for_geometry(mits_info_df.loc[obk_needed])
+            mits_info_df = mits_info_df.join(
+                obk.for_geometry(mits_info_df.loc[obk_needed])
+            )
 
         ### Mitsen checken
         for idx, row in self.gdf.iterrows():

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -1165,7 +1165,7 @@ class Kartering:
         changes = gdf["_VegTypeInfo"] != altered_vegtypes
         if changes.any():
             logging.warning(
-                f"Er zijn handmatige wijzigingen in de vegetatietypen. Deze worden overgenomen op indices: {gdf['ElmID'][changes].to_list()}"
+                f"Er zijn handmatige wijzigingen in de vegetatietypen. Deze worden overgenomen. Veranderde vlakken: ElmID={gdf['ElmID'][changes].to_list()}"
             )
 
         gdf["VegTypeInfo"] = altered_vegtypes
@@ -1588,7 +1588,7 @@ class Kartering:
                     or new_kwaliteit != old_keuze.kwaliteit.as_letter()
                 ):
                     logging.warning(
-                        f"Er zijn handmatige wijzigingen in de habitattypes. Deze worden overgenomen. In regel: ElmID={gdf['ElmID'].iloc[row_idx]}"
+                        f"Er zijn handmatige wijzigingen in de habitattypes. Deze worden overgenomen. In vlak: ElmID={gdf['ElmID'].iloc[row_idx]}"
                     )
                     old_keuze.status = KeuzeStatus.HANDMATIG_TOEGEKEND
                     old_keuze.habtype = new_habtype


### PR DESCRIPTION
3 kleine fixjes:
- `funtionele_samenhang.py`: Als een vlak naar H0000 gaat wordt nu ook de kwaliteit naar NVT gezet. Ook printen we de kwaliteit die het ooit had, en wordt er niet meer "None" meegegeven in de nieuwe opmerking als de oude opmerking None was.
- `main.py`: reverse() blijkt in place te zijn
- `vegkartering.py`: Output van veranderde vegtypen/habtypen verduidelijkt, en obk verrijking gefixt.