### PR TITLE
SPH-993 - Always show all habitatvoorstellen

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,7 @@ Verder zijn er een aantal kolommen die gelden voor het hele vlak, en kolommen di
 
 **f_VvNdftbl{i}**/**f_SBBdftbl{i}**: Deze kolommen bevatten een lijst met alle vegetatietypen die voor dit vlak zijn teruggevonden in de definitietabel, welke regel van de definitietabel het betreft, en naar welk habitattype het vlak mogelijk vertaalt. Een waarde `---` in `f_VvNdftbl` betekent dat de regel is gevonden op SBB-code, en vice-versa.
 
-**f_Mits_opm{i}**/**f_Mozk_opm{i}**: Hier staat informatie over de mitsen/mozaiekregels die in definitietabelregels gevonden zijn.
-
-Voor ieder beperkend criterium en mozaiekregel is weergegeven of deze klopt (`TRUE`), niet klopt (`FALSE`), of niet door veg2hab beoordeeld kan worden (`CANNOT_BE_AUTOMATED`). Een mozaiekregel kan ook nog uitgesteld zijn (`POSTPONE`); in dit geval is er te weinig informatie over de habitattypen van omliggende vlakken, omdat deze nog te veel HXXXX hebben om een mozaiekregeloordeel te kunnen vellen.
+**f_Mits_opm{i}**/**f_Mozk_opm{i}**: Hier staat informatie over de mitsen/mozaiekregels die in definitietabelregels gevonden zijn. Voor ieder beperkend criterium en mozaiekregel is weergegeven of deze klopt (`TRUE`), niet klopt (`FALSE`), of niet door veg2hab beoordeeld kan worden (`CANNOT_BE_AUTOMATED`). Een mozaiekregel kan ook nog uitgesteld zijn (`POSTPONE`); in dit geval is er te weinig informatie over de habitattypen van omliggende vlakken, omdat deze nog te veel HXXXX hebben om een mozaiekregeloordeel te kunnen vellen.
 
 **f_MozkPerc{i}**: Als dit complex-deel een mozaiekregel heeft, zijn hier de omringingspercentages van aangenzende habitattypen weergegeven. De getoonde percentages zijn diegene die gebruikt zijn om de mozaiekregel te beoordelen. Aangezien het mogelijk is dat een mozaiekregel beoordeeld kan worden voordat alle omliggende vlakken al een habitattype hebben gekregen (bijvoorbeeld als er al 50% van een verkeerd habitattype omheen ligt), kloppen deze soms niet met wat uiteindelijk om het vlak ligt (er kan meer HXXXX staan dan in de output kartering zo is).
 

--- a/README.md
+++ b/README.md
@@ -237,11 +237,13 @@ Verder zijn er een aantal kolommen die gelden voor het hele vlak, en kolommen di
 
 **ElmID**: Een uniek ID voor ieder vlak. Deze wordt in eerste instantie overgenomen uit de bronkartering, tenzij deze niet voor ieder vlak uniek is; in dat geval is een warning gegeven en is er een nieuw uniek ID voor ieder vlak aangemaakt.
 
-**_Samnvttng**: Verkorte weergave met toegekende habitattypen en hun percentages in het complex. Dit is een combinatie van alle kolommen `Habtype{i}` en `Perc{i}`.
+**f_Samnvttng**: Verkorte weergave met toegekende habitattypen en hun percentages in het complex. Dit is een combinatie van alle kolommen `Habtype{i}` en `Perc{i}`.
 
-**_LokVegTyp**: Het in de bronkartering opgegeven lokale vegetatietype, als er een lokaal vegetatietype kolom is opgegeven.
+**f_LokVegTyp**: Het in de bronkartering opgegeven lokale vegetatietype, als er een lokaal vegetatietype kolom is opgegeven.
 
-**_LokVrtNar**: De landelijke typologie waar lokale vegetatietypen in de bronkartering naar zijn vertaald (SBB, VvN of beide). Als dit SBB is, zijn de bijbehorende VvN-typen door veg2hab uit de waswordtlijst gehaald. Als er naar VvN of naar beide is vertaald, wordt deze stap overgeslagen.
+**f_LokVrtNar**: De landelijke typologie waar lokale vegetatietypen in de bronkartering naar zijn vertaald (SBB, VvN of beide). Als dit SBB is, zijn de bijbehorende VvN-typen door veg2hab uit de waswordtlijst gehaald. Als er naar VvN of naar beide is vertaald, wordt deze stap overgeslagen.
+
+**f_state**: De huidige status van de kartering. Deze veranderd afhankelijk van de uitgevoerde tool (1a/1b/2 = `POST_WWL`, 3 = `MITS_HABKEUZES`, 4 = `MOZAIEK_HABKEUZES`, 5 = `FUNC_SAMENHANG`). Deze is voornamelijk voor intern gebruik.
 
 ### Kolommen per deel van het complex
 **Habtype{i}**: Habitattype dat door veg2hab is toegekend aan dit complex-deel. HXXXX betekent dat er nog geen eenduidig habitattype kan worden toegekend. Hiervoor is nog een vervolgstap in veg2hab of handmatige inspectie nodig.
@@ -256,7 +258,7 @@ Verder zijn er een aantal kolommen die gelden voor het hele vlak, en kolommen di
 
 **VvN{i}**/**SBB{i}**: De VvN- en/of SBB-code die door de bronkartering aan het complex-deel zijn toegekend. Een waarde `Null` of `None` betekent dat in de bronkartering voor deze typologie is opgegeven, en dat de waswordtlijst ook geen vertaling bevat.
 
-**_Status{i}**: Beslissings-status van veg2hab voor dit complex-deel. Kolom `_Uitleg{i}` geeft verdere uitleg over deze status. Mogelijke statussen en hun uitleg zijn:
+**f_Status{i}**: Beslissings-status van veg2hab voor dit complex-deel. Kolom `f_Uitleg{i}` geeft verdere uitleg over deze status. Mogelijke statussen en hun uitleg zijn:
 - `HABITATTYPE_TOEGEKEND`: veg2hab heeft één habitattype gevonden waaraan dit vlak voldoet.
 - `VOLDOET_AAN_MEERDERE_HABTYPEN`: veg2hab heeft meerdere habitattypen gevonden waaraan dit vlak voldoet. De gebruiker moet hierin een keuze maken.
 - `VOLDOET_NIET_AAN_HABTYPEVOORWAARDEN`: Het vlak voldoet niet aan de beperkende criteria en/of mozaiekregels voor de habitattypen die mogelijk van toepassing zijn. veg2hab kent aan dit vlak H0000 toe.
@@ -267,19 +269,15 @@ Verder zijn er een aantal kolommen die gelden voor het hele vlak, en kolommen di
 - `WACHTEN_OP_MOZAIEK`: De mozaiekregels zijn nog niet toegepast, of er is te weinig informatie over de habitattypen van omliggende vlakken (teveel HXXXX).
 - `MINIMUM_OPP_NIET_GEHAALD`: het vlak voldoet aan de voorwaarden voor een habitattype, maar haalt (in functionele samenhang) niet het minimum benodigde oppervlak.
 
-**_Uitleg{i}**: Uitleg bij de kolom `_Status{i}` van dit complex-deel.
+**f_Uitleg{i}**: Uitleg bij de kolom `f_Status{i}` van dit complex-deel.
 
-**_VvNdftbl{i}**/**_SBBdftbl{i}**: Deze kolommen bevatten een lijst met alle vegetatietypen die voor dit vlak zijn teruggevonden in de definitietabel, welke regel van de definitietabel het betreft, en naar welk habitattype het vlak mogelijk vertaalt. Een waarde `None` in `_VvNdftbl` betekent dat de regel is gevonden op SBB-code, en vice-versa.
+**f_VvNdftbl{i}**/**f_SBBdftbl{i}**: Deze kolommen bevatten een lijst met alle vegetatietypen die voor dit vlak zijn teruggevonden in de definitietabel, welke regel van de definitietabel het betreft, en naar welk habitattype het vlak mogelijk vertaalt. Een waarde `---` in `f_VvNdftbl` betekent dat de regel is gevonden op SBB-code, en vice-versa.
 
-**_Mits_opm{i}**/**_Mozk_opm{i}**: Hier staat informatie over de mitsen/mozaiekregels die in definitietabelregels gevonden zijn. Wat hier staat hangt af van de status:
-- `VOLDOET_AAN_MEERDERE_HABTYPEN`, `NIET_GEAUTOMATISEERD_CRITERIUM`, `WACHTEN_OP_MOZAIEK`: De beperkende criteria en mozaiekregels worden getoond van *alle* definitietabelregels die mogelijk op het vlak van toepassing zijn. Definitietabelregels waarvan veg2hab volledig heeft kunnen controleren dat ze *niet* van toepassing zijn, worden weggelaten.
-- `VOLDOET_NIET_AAN_HABTYPEVOORWAARDEN`: Alle beperkende criteria en mozaiekregels worden getoond. Deze kloppen allemaal niet, anders zou het vlak een habitattype (of HXXXX) hebben gekregen.
-- `HABITATTYPE_TOEGEKEND`, `MINIMUM_OPP_NIET_GEHAALD`: Alleen de beperkende criteria en mozaiekregel van de regel uit de definitietabel die tot het habitattype hebben geleid, worden getoond.
-- `VEGTYPEN_NIET_IN_DEFTABEL`, `GEEN_OPGEGEVEN_VEGTYPEN`, `NIET_GEAUTOMATISEERD_VEGTYPE`: Er zijn geen regels in de definitietabel gevonden voor de huidige vegetatietypen, dus er worden ook geen mitsen/mozaiekregels weergegeven.
+**f_Mits_opm{i}**/**f_Mozk_opm{i}**: Hier staat informatie over de mitsen/mozaiekregels die in definitietabelregels gevonden zijn.
 
 Voor ieder beperkend criterium en mozaiekregel is weergegeven of deze klopt (`TRUE`), niet klopt (`FALSE`), of niet door veg2hab beoordeeld kan worden (`CANNOT_BE_AUTOMATED`). Een mozaiekregel kan ook nog uitgesteld zijn (`POSTPONE`); in dit geval is er te weinig informatie over de habitattypen van omliggende vlakken, omdat deze nog te veel HXXXX hebben om een mozaiekregeloordeel te kunnen vellen.
 
-**_MozkPerc{i}**: Als dit complex-deel een mozaiekregel heeft, zijn hier de omringingspercentages van aangenzende habitattypen weergegeven. De getoonde percentages zijn diegene die gebruikt zijn om de mozaiekregel te beoordelen. Aangezien het mogelijk is dat een mozaiekregel beoordeeld kan worden voordat alle omliggende vlakken al een habitattype hebben gekregen (bijvoorbeeld als er al 50% van een verkeerd habitattype omheen ligt), kloppen deze soms niet met wat uiteindelijk om het vlak ligt (er kan meer HXXXX staan dan in de output kartering zo is).
+**f_MozkPerc{i}**: Als dit complex-deel een mozaiekregel heeft, zijn hier de omringingspercentages van aangenzende habitattypen weergegeven. De getoonde percentages zijn diegene die gebruikt zijn om de mozaiekregel te beoordelen. Aangezien het mogelijk is dat een mozaiekregel beoordeeld kan worden voordat alle omliggende vlakken al een habitattype hebben gekregen (bijvoorbeeld als er al 50% van een verkeerd habitattype omheen ligt), kloppen deze soms niet met wat uiteindelijk om het vlak ligt (er kan meer HXXXX staan dan in de output kartering zo is).
 
 
 

--- a/notebooks/functionality_test.ipynb
+++ b/notebooks/functionality_test.ipynb
@@ -29,6 +29,7 @@
                 "from veg2hab import constants\n",
                 "import pandas as pd\n",
                 "from veg2hab.bronnen import FGR, Bodemkaart, LBK, OudeBossenkaart\n",
+                "from veg2hab.enums import WelkeTypologie\n",
                 "\n",
                 "pd.set_option('display.max_columns', 100)\n",
                 "\n",
@@ -99,7 +100,7 @@
             "outputs": [],
             "source": [
                 "shp_path = Path(\"../testing/vegetatiekarteringen/GR/SGL Hunzedal en Leekstermeer2021/2021 Vegetatiekartering Leekstermeer2021/GIS bestanden Onlanden 2021/Vegetatiekartering_Leekstermeer2021.shp\")\n",
-                "Kartering.from_shapefile(shp_path, vegtype_col_format=\"single\", sbb_of_vvn=\"SBB\", ElmID_col=\"elmid\", SBB_col=[\"SBBTYPE\"], VvN_col=[], split_char=\"+\", lok_vegtypen_col=[\"Vegtype\"]).gdf"
+                "Kartering.from_shapefile(shp_path, vegtype_col_format=\"single\", welke_typologie=WelkeTypologie.SBB, ElmID_col=\"elmid\", SBB_col=[\"SBBTYPE\"], VvN_col=[], rVvN_col=[], split_char=\"+\", lok_vegtypen_col=[\"Vegtype\"]).gdf"
             ]
         },
         {
@@ -125,7 +126,7 @@
                 "csvs_path = Path(\"../data/notebook_data/Rottige_Meenthe_Brandemeer_2013/864_RottigeMeenthe2013.mdb\")\n",
                 "shape_elm_id_column = \"ElmID\"\n",
                 "\n",
-                "access_kartering = Kartering.from_access_db(shape_path, shape_elm_id_column, csvs_path)\n",
+                "access_kartering = Kartering.from_access_db(shape_path, shape_elm_id_column, csvs_path, WelkeTypologie.SBB)\n",
                 "\n",
                 "access_kartering.gdf.head(3)\n"
             ]

--- a/veg2hab/habitat.py
+++ b/veg2hab/habitat.py
@@ -80,7 +80,7 @@ class HabitatVoorstel(BaseModel):
         if self.habtype_naam != "":
             hab_str += f" ({self.habtype_naam})"
 
-        return f"[{veg_str} -> {hab_str}]"
+        return f"{veg_str} -> {hab_str}"
 
     def get_VvNdftbl_str(self):
         if isinstance(self.vegtype_in_dt, SBB):
@@ -324,8 +324,18 @@ def try_to_determine_habkeuze(
                     kwaliteit=voorstel.kwaliteit,
                     habitatvoorstellen=[voorstel],
                     opmerking="",
-                    mits_opmerking=f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}]",
-                    mozaiek_opmerking=f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}]",
+                    mits_opmerking="\n".join(
+                        [
+                            f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}"
+                            for nr, voorstel in enumerate(all_voorstellen)
+                        ]
+                    ),
+                    mozaiek_opmerking="\n".join(
+                        [
+                            f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}"
+                            for nr, voorstel in enumerate(all_voorstellen)
+                        ]
+                    ),
                     debug_info="",
                 )
 
@@ -346,18 +356,18 @@ def try_to_determine_habkeuze(
                         status=KeuzeStatus.HABITATTYPE_TOEGEKEND,
                         habtype=true_voorstellen[0].habtype,
                         kwaliteit=true_voorstellen[0].kwaliteit,
-                        habitatvoorstellen=true_voorstellen,
+                        habitatvoorstellen=all_voorstellen,
                         opmerking=f"",
                         mits_opmerking="\n".join(
                             [
-                                f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}]"
-                                for voorstel in true_voorstellen
+                                f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}"
+                                for nr, voorstel in enumerate(all_voorstellen)
                             ]
                         ),
                         mozaiek_opmerking="\n".join(
                             [
-                                f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}]"
-                                for voorstel in true_voorstellen
+                                f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}"
+                                for nr, voorstel in enumerate(all_voorstellen)
                             ]
                         ),
                         debug_info="",
@@ -366,18 +376,18 @@ def try_to_determine_habkeuze(
                     status=KeuzeStatus.VOLDOET_AAN_MEERDERE_HABTYPEN,
                     habtype="HXXXX",
                     kwaliteit=Kwaliteit.NVT,
-                    habitatvoorstellen=true_voorstellen,
+                    habitatvoorstellen=all_voorstellen,
                     opmerking="",
                     mits_opmerking="\n".join(
                         [
-                            f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}]"
-                            for voorstel in true_voorstellen
+                            f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}"
+                            for nr, voorstel in enumerate(all_voorstellen)
                         ]
                     ),
                     mozaiek_opmerking="\n".join(
                         [
-                            f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}]"
-                            for voorstel in true_voorstellen
+                            f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}"
+                            for nr, voorstel in enumerate(all_voorstellen)
                         ]
                     ),
                     debug_info="",
@@ -410,18 +420,18 @@ def try_to_determine_habkeuze(
                 status=KeuzeStatus.NIET_GEAUTOMATISEERD_CRITERIUM,
                 habtype="HXXXX",
                 kwaliteit=Kwaliteit.NVT,
-                habitatvoorstellen=return_voorstellen,
+                habitatvoorstellen=all_voorstellen,
                 opmerking="",
                 mits_opmerking="\n".join(
                     [
-                        f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}]"
-                        for voorstel in return_voorstellen
+                        f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}"
+                        for nr, voorstel in enumerate(all_voorstellen)
                     ]
                 ),
                 mozaiek_opmerking="\n".join(
                     [
-                        f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}]"
-                        for voorstel in return_voorstellen
+                        f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}"
+                        for nr, voorstel in enumerate(all_voorstellen)
                     ]
                 ),
                 debug_info="",
@@ -450,18 +460,18 @@ def try_to_determine_habkeuze(
                 status=KeuzeStatus.WACHTEN_OP_MOZAIEK,
                 habtype="HXXXX",
                 kwaliteit=Kwaliteit.NVT,
-                habitatvoorstellen=return_voorstellen,
+                habitatvoorstellen=all_voorstellen,
                 opmerking="",
                 mits_opmerking="\n".join(
                     [
-                        f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}]"
-                        for voorstel in return_voorstellen
+                        f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}"
+                        for nr, voorstel in enumerate(all_voorstellen)
                     ]
                 ),
                 mozaiek_opmerking="\n".join(
                     [
-                        f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}]"
-                        for voorstel in return_voorstellen
+                        f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}"
+                        for nr, voorstel in enumerate(all_voorstellen)
                     ]
                 ),
                 debug_info="",
@@ -476,14 +486,14 @@ def try_to_determine_habkeuze(
         opmerking="",
         mits_opmerking="\n".join(
             [
-                f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}]"
-                for voorstel in all_voorstellen
+                f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mits}, {voorstel.mits.evaluation}"
+                for nr, voorstel in enumerate(all_voorstellen)
             ]
         ),
         mozaiek_opmerking="\n".join(
             [
-                f"[{voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}]"
-                for voorstel in all_voorstellen
+                f"{nr + 1}. {voorstel.vegtype_in_dt}, {voorstel.habtype}, {voorstel.mozaiek}, {voorstel.mozaiek.evaluation}"
+                for nr, voorstel in enumerate(all_voorstellen)
             ]
         ),
         debug_info="",

--- a/veg2hab/habitat.py
+++ b/veg2hab/habitat.py
@@ -402,20 +402,6 @@ def try_to_determine_habkeuze(
         # Als er een CANNOT_BE_AUTOMATED is...
         if MaybeBoolean.CANNOT_BE_AUTOMATED in truth_values:
             # ...dan kunnen we voor de huidige voorstellen geen keuze maken
-
-            # We weten wel dat habitatvoorstellen met een specifieker matchniveau dan die van
-            # de current_voorstellen allemaal FALSE waren, dus die hoeven we niet terug te geven
-            # We filteren ook mits&mozaiek eruit die FALSE zijn; die hangen nm toch niet van een NietGeautomatiseerdCriterium af.
-            return_voorstellen = [
-                voorstel
-                for voorstel in all_voorstellen
-                if voorstel.match_level <= current_voorstellen[0].match_level
-                and (
-                    voorstel.mits.evaluation & voorstel.mozaiek.evaluation
-                    != MaybeBoolean.FALSE
-                )
-            ]
-
             return HabitatKeuze(
                 status=KeuzeStatus.NIET_GEAUTOMATISEERD_CRITERIUM,
                 habtype="HXXXX",
@@ -441,21 +427,8 @@ def try_to_determine_habkeuze(
         if MaybeBoolean.POSTPONE in truth_values:
             # ...dan komt dat door een mozaiekregel waar nog te weinig info over omliggende vlakken voor is
 
-            # We weten wel dat habitatvoorstellen met een specifieker matchniveau dan die van
-            # de current_voorstellen allemaal FALSE waren, dus die hoeven we niet terug te geven
-            # We filteren ook mits&mozaiek eruit die FALSE zijn; die hangen nm toch niet van een NietGeautomatiseerdCriterium af.
-            return_voorstellen = [
-                voorstel
-                for voorstel in all_voorstellen
-                if voorstel.match_level <= current_voorstellen[0].match_level
-                and (
-                    voorstel.mits.evaluation & voorstel.mozaiek.evaluation
-                    != MaybeBoolean.FALSE
-                )
-            ]
-
             # Deze keuze komt volgende iteratieronde terug
-            # Als de huidige iteratie de laatste is (bv omdat er geen voortang is gemaakt), dan komt deze keuze in de output terecht.
+            # Als de huidige iteratie de laatste is (bv omdat er geen voortgang is gemaakt), dan komt deze keuze in de output terecht.
             return HabitatKeuze(
                 status=KeuzeStatus.WACHTEN_OP_MOZAIEK,
                 habtype="HXXXX",

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -375,19 +375,19 @@ def hab_as_final_format(print_info: tuple, idx: int, opp: float) -> pd.Series:
             f"_Mits_info{idx}": keuze.mits_opmerking,
             f"_Mozk_info{idx}": keuze.mozaiek_opmerking,
             f"_MozkPerc{idx}": "\n".join(
-                voorstel.mozaiek.get_mozk_perc_str() for voorstel in voorstellen
+                f"{nr + 1}. " + voorstel.mozaiek.get_mozk_perc_str() for nr, voorstel in enumerate(voorstellen)
             ),
             # f"Bron{idx}" TODO: Naam van de kartering, voegen we later toe
-            f"VvN{idx}": ", ".join(str(code) for code in vegtypeinfo.VvN),
-            f"SBB{idx}": ", ".join(str(code) for code in vegtypeinfo.SBB),
+            f"VvN{idx}": ", ".join(f"{nr + 1}. " + str(code) for nr, code in enumerate(vegtypeinfo.VvN)),
+            f"SBB{idx}": ", ".join(f"{nr + 1}. " + str(code) for nr, code in enumerate(vegtypeinfo.SBB)),
             # f"VEGlok{idx}" TODO: Doen we voor nu nog even niet
             f"_Status{idx}": str(keuze.status),
             f"_Uitleg{idx}": keuze.status.toelichting,
             f"_VvNdftbl{idx}": "\n".join(
-                voorstel.get_VvNdftbl_str() for voorstel in voorstellen
+                f"{nr + 1}. " + voorstel.get_VvNdftbl_str() for nr, voorstel in enumerate(voorstellen)
             ),
             f"_SBBdftbl{idx}": "\n".join(
-                voorstel.get_SBBdftbl_str() for voorstel in voorstellen
+                f"{nr + 1}. " + voorstel.get_SBBdftbl_str() for nr, voorstel in enumerate(voorstellen)
             ),
         }
 

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -375,19 +375,22 @@ def hab_as_final_format(print_info: tuple, idx: int, opp: float) -> pd.Series:
             f"_Mits_info{idx}": keuze.mits_opmerking,
             f"_Mozk_info{idx}": keuze.mozaiek_opmerking,
             f"_MozkPerc{idx}": "\n".join(
-                f"{nr + 1}. " + voorstel.mozaiek.get_mozk_perc_str() for nr, voorstel in enumerate(voorstellen)
+                f"{nr + 1}. " + voorstel.mozaiek.get_mozk_perc_str()
+                for nr, voorstel in enumerate(voorstellen)
             ),
             # f"Bron{idx}" TODO: Naam van de kartering, voegen we later toe
-            f"VvN{idx}": ", ".join(f"{nr + 1}. " + str(code) for nr, code in enumerate(vegtypeinfo.VvN)),
-            f"SBB{idx}": ", ".join(f"{nr + 1}. " + str(code) for nr, code in enumerate(vegtypeinfo.SBB)),
+            f"VvN{idx}": ", ".join(str(code) for code in vegtypeinfo.VvN),
+            f"SBB{idx}": ", ".join(str(code) for code in vegtypeinfo.SBB),
             # f"VEGlok{idx}" TODO: Doen we voor nu nog even niet
             f"_Status{idx}": str(keuze.status),
             f"_Uitleg{idx}": keuze.status.toelichting,
             f"_VvNdftbl{idx}": "\n".join(
-                f"{nr + 1}. " + voorstel.get_VvNdftbl_str() for nr, voorstel in enumerate(voorstellen)
+                f"{nr + 1}. " + voorstel.get_VvNdftbl_str()
+                for nr, voorstel in enumerate(voorstellen)
             ),
             f"_SBBdftbl{idx}": "\n".join(
-                f"{nr + 1}. " + voorstel.get_SBBdftbl_str() for nr, voorstel in enumerate(voorstellen)
+                f"{nr + 1}. " + voorstel.get_SBBdftbl_str()
+                for nr, voorstel in enumerate(voorstellen)
             ),
         }
 


### PR DESCRIPTION
Naar aanleiding van Hinko's verwarring over waarom soms bepaalde deftabelregels wel in de output staan en wanneer niet, tonen we nu altijd alle regels. Ook heb ik nummering van de regels in de output toegevoegd, zo is het makkelijker te volgen wat waarbij hoort:

![image](https://github.com/user-attachments/assets/99e06bcc-85d1-41c9-99e5-35b776444f2b)

Ik heb ook de readme een beetje geupdatet. Ik heb weggehaald wanneer welke deftabel regels getoond worden en ik heb de namen van de _ kolommen een f voor gezet.
