### PR TITLE
SPH-1020 - ElmID is BIG INTEGER en kan niet als geodatabase weggeschreven worden

### DIFF
--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -729,6 +729,10 @@ class Kartering:
         if not self.gdf["ElmID"].is_unique:
             raise ValueError("ElmID is niet uniek")
 
+        # ArcGIS maakt van elke smaak int een Big Integer, wat het vervolgens niet op kan slaan in een GeoDataBase. 
+        # Dus we maken van ElmID een float64 (net als dat Area en andere getallen dat zijn).
+        self.gdf.ElmID = self.gdf.ElmID.astype("float64")
+
     def check_state(self, *states: KarteringState):
         """
         Checkt of de kartering (een van de) de gegeven state(s) heeft

--- a/veg2hab/vegkartering.py
+++ b/veg2hab/vegkartering.py
@@ -729,7 +729,7 @@ class Kartering:
         if not self.gdf["ElmID"].is_unique:
             raise ValueError("ElmID is niet uniek")
 
-        # ArcGIS maakt van elke smaak int een Big Integer, wat het vervolgens niet op kan slaan in een GeoDataBase. 
+        # ArcGIS maakt van elke smaak int een Big Integer, wat het vervolgens niet op kan slaan in een GeoDataBase.
         # Dus we maken van ElmID een float64 (net als dat Area en andere getallen dat zijn).
         self.gdf.ElmID = self.gdf.ElmID.astype("float64")
 


### PR DESCRIPTION
Ik heb er uiteindelijk maar een float64 van gemaakt, want van int16/int32 maakte ArcGIS alsnog een BIG INTEGER en wilde hij t alsnog niet wegschrijven.